### PR TITLE
fix: exec run.sh with bash, not sh

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -9,7 +9,7 @@ description = "Full-height nvim sidebar with agent annotations: toggle with one 
 id = "toggle"
 title = "nvim sidebar: toggle"
 contexts = ["pane", "workspace"]
-command = ["sh", "-c", "exec sh \"$HERDR_PLUGIN_ROOT/herdr/run.sh\" toggle"]
+command = ["sh", "-c", "exec bash \"$HERDR_PLUGIN_ROOT/herdr/run.sh\" toggle"]
 
 # Overlay pane that renders the file picker. Opened programmatically by the
 # `pick-file` action (via `herdr plugin pane open --entrypoint picker`), which
@@ -18,20 +18,20 @@ command = ["sh", "-c", "exec sh \"$HERDR_PLUGIN_ROOT/herdr/run.sh\" toggle"]
 id = "picker"
 title = "open file"
 placement = "popup"
-command = ["sh", "-c", "exec sh \"$HERDR_PLUGIN_ROOT/herdr/run.sh\" picker"]
+command = ["sh", "-c", "exec bash \"$HERDR_PLUGIN_ROOT/herdr/run.sh\" picker"]
 
 [[actions]]
 id = "pick-file"
 title = "nvim sidebar: open file from agent output"
 contexts = ["pane"]
-command = ["sh", "-c", "exec sh \"$HERDR_PLUGIN_ROOT/herdr/run.sh\" pick-file"]
+command = ["sh", "-c", "exec bash \"$HERDR_PLUGIN_ROOT/herdr/run.sh\" pick-file"]
 
 # Invoked by herdr on Ctrl+click of a link_handlers match below — never bound
 # to a key or palette entry directly.
 [[actions]]
 id = "open-link"
 title = "nvim sidebar: open clicked file"
-command = ["sh", "-c", "exec sh \"$HERDR_PLUGIN_ROOT/herdr/run.sh\" open-link"]
+command = ["sh", "-c", "exec bash \"$HERDR_PLUGIN_ROOT/herdr/run.sh\" open-link"]
 
 # Linkify plain-text file paths in every pane's output. Conservative: requires
 # a directory segment + extension (bare `README.md` stays unlinkified to avoid


### PR DESCRIPTION
Fixes #3

`herdr/run.sh` is a bash script (`set -euo pipefail`), but `herdr-plugin.toml` invoked it as `exec sh run.sh`. On systems where `/bin/sh` is dash (Debian/Ubuntu/WSL), this fails immediately with `set: Illegal option -o pipefail`, exit code 2 — so `toggle`, `picker`, `pick-file`, and `open-link` all silently no-op. macOS didn't surface this because `/bin/sh` there is bash running in POSIX mode, which still supports `pipefail`.

Changed `exec sh` → `exec bash` in all 4 `command = [...]` entries in `herdr-plugin.toml`.

## Testing

- Reproduced the exact reported error in a `debian:12-slim` container (dash as `/bin/sh`): `herdr/run.sh: 5: set: Illegal option -o pipefail`, exit 2.
- Confirmed the fix resolves it at the shell level for all 4 actions in the same container.
- Built `herdr-nvim` for Linux in a `rust:bookworm` container and ran the fixed command end-to-end — it now fails only on the expected `HERDR_WORKSPACE_ID` runtime precondition (set by herdr itself), with no shell error.