### PR TITLE
feat(config): support nvim_env overrides for the sidebar nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ command = "chmarax.herdr-nvim.pick-file"
 description = "open file from agent output"
 ```
 
-**2. The nvim plugin** (annotations), with lazy.nvim:
+**2. The nvim plugin** (annotations), with your plugin manager (e.g. lazy.nvim):
 
 ```lua
 { "ChmaraX/herdr-nvim", opts = {} }
@@ -126,14 +126,26 @@ malformed files fall back to these defaults):
 
 ```toml
 [sidebar]
-nvim_bin = "nvim"   # binary used to spawn the per-tab nvim daemon
-position = "right"   # right (default), left, top, or bottom
+nvim_bin = "nvim"     # binary used to spawn the per-tab nvim daemon
+nvim_env = []         # env overrides for that nvim, applied to the daemon,
+                      # the sidebar window, and open-file clients. For
+                      # example, nvim_env = ["NVIM_APPNAME=myapp"] runs the
+                      # sidebar under the config in ~/.config/myapp instead
+                      # of vanilla nvim (replace myapp with your app name).
+position = "right"    # right (default), left, top, or bottom
 
 [picker]
 scan_lines = 300    # pane lines scanned by the fallback text-scrape
 max_files = 20      # session entries shown before you type a query
                     # (a typed query fuzzy-searches the whole repo, uncapped)
 ```
+
+If your normal nvim config lives under a custom `NVIM_APPNAME` (any name you
+launch `nvim` with — e.g. a distro or your own config directory), set
+`sidebar.nvim_env = ["NVIM_APPNAME=myapp"]` so the sidebar's daemon and window
+run that configuration too. Without it the sidebar is vanilla nvim. The daemon
+still injects this plugin's lua over runtimepath after your config loads
+(VimEnter fallback), so annotations work under any appname.
 
 ## Troubleshooting
 

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -246,7 +246,7 @@ pub(crate) fn open_in_sidebar(
     let sidebar_cmd = daemon::sidebar_shell_cmd(&ctx.tab, &ctx.cwd);
     let sidebar = ensure_sidebar_open(h, ctx, &sidebar_cmd)?;
 
-    open_in_nvim(&socket, path, line, &config.sidebar.nvim_bin)?;
+    open_in_nvim(&socket, path, line, &config.sidebar)?;
     focus_pane(&sidebar);
     Ok(())
 }
@@ -278,10 +278,15 @@ fn ensure_sidebar_open(h: &mut dyn Herdr, ctx: &Ctx, sidebar_cmd: &str) -> Resul
 /// a buffer literally named `+5` and leaves the cursor on line 1), so `+<line>`
 /// only works when *launching* nvim, not against a running server. `--remote-expr`
 /// is also mode-independent (works even mid-insert) and needs no path escaping.
-fn open_in_nvim(socket: &Path, path: &str, line: Option<u32>, nvim_bin: &str) -> Result<()> {
+fn open_in_nvim(
+    socket: &Path,
+    path: &str,
+    line: Option<u32>,
+    sidebar: &crate::config::Sidebar,
+) -> Result<()> {
     // Open (or focus) the file. `--remote` takes the path as a clean argv, so a
     // path with spaces needs no escaping.
-    let status = daemon::nvim_cmd(nvim_bin)
+    let status = daemon::nvim_cmd(sidebar)
         .arg("--server")
         .arg(socket)
         .arg("--remote")
@@ -293,7 +298,7 @@ fn open_in_nvim(socket: &Path, path: &str, line: Option<u32>, nvim_bin: &str) ->
     }
     // Jump to the line, if known.
     if let Some(line) = line {
-        let status = daemon::nvim_cmd(nvim_bin)
+        let status = daemon::nvim_cmd(sidebar)
             .arg("--server")
             .arg(socket)
             .arg("--remote-expr")

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 //! Herdr-side TOML config: `~/.config/herdr-nvim/config.toml` (or
-//! `HERDR_NVIM_CONFIG` override). Controls the nvim binary used to spawn/attach
-//! the daemon, how many trailing pane lines the file-picker scans, and how
-//! many entries the picker's default (unfiltered) view shows.
+//! `HERDR_NVIM_CONFIG` override). Controls how the sidebar's nvim processes
+//! run (binary + environment), how many trailing pane lines the file-picker
+//! scans, and how many entries the picker's default (unfiltered) view shows.
 //!
 //! Missing file -> defaults, silently. Malformed file -> defaults, with one
 //! warning on stderr (never panics or fails the caller).
@@ -9,6 +9,14 @@
 use std::{env, fs, path::PathBuf};
 
 use serde::Deserialize;
+
+/// Whether `key` is safe as an environment-variable name: non-empty ASCII
+/// alphanumeric/underscore (so nvim's `~/.config/<name>` lookups can never be
+/// redirected outside the normal nvim namespace by a stray path separator),
+/// and never `=`/NUL (which would make `Command::env` itself reject it).
+fn is_valid_env_key(key: &str) -> bool {
+    !key.is_empty() && key.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}
 
 #[derive(Deserialize, Default, PartialEq, Eq, Debug)]
 pub struct Config {
@@ -18,10 +26,17 @@ pub struct Config {
     pub picker: Picker,
 }
 
-#[derive(Deserialize, PartialEq, Eq, Debug)]
+#[derive(Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct Sidebar {
     #[serde(default = "default_nvim_bin")]
     pub nvim_bin: String,
+    /// Environment overrides applied to every nvim this plugin spawns or
+    /// attaches to (sidebar daemon, `--remote-ui` window, health probes,
+    /// open-file clients). Each entry must be `KEY=VALUE`; a typical use is
+    /// `NVIM_APPNAME=myapp` to run the sidebar under the nvim config that
+    /// lives in `~/.config/myapp` instead of vanilla nvim.
+    #[serde(default)]
+    pub nvim_env: Vec<String>,
     #[serde(default)]
     pub position: SidebarPosition,
 }
@@ -30,8 +45,31 @@ impl Default for Sidebar {
     fn default() -> Self {
         Self {
             nvim_bin: default_nvim_bin(),
+            nvim_env: Vec::new(),
             position: SidebarPosition::default(),
         }
+    }
+}
+
+impl Sidebar {
+    /// The configured environment overrides as parsed `(key, value)` pairs,
+    /// applied to every `nvim_cmd` caller. Each is an env var on the child
+    /// (an unordered set; duplicate keys resolve to the last value written).
+    /// Malformed entries (no `=`, or a key that is not an env-style name) are
+    /// skipped; `load()` warns about them once so a typo degrades to default
+    /// behavior instead of breaking the sidebar.
+    pub(crate) fn env_override(&self) -> Vec<(&str, &str)> {
+        self.nvim_env
+            .iter()
+            .filter_map(|entry| {
+                let (key, value) = entry.split_once('=')?;
+                if is_valid_env_key(key) {
+                    Some((key, value))
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 }
 
@@ -103,8 +141,28 @@ pub fn load() -> Config {
         Ok(raw) => raw,
         Err(_) => return Config::default(),
     };
-    match toml::from_str(&raw) {
-        Ok(config) => config,
+    let parsed: Result<Config, toml::de::Error> = toml::from_str(&raw);
+    match parsed {
+        Ok(config) => {
+            let invalid: Vec<&str> = config
+                .sidebar
+                .nvim_env
+                .iter()
+                .filter(|entry| {
+                    entry
+                        .split_once('=')
+                        .is_none_or(|(key, _)| !is_valid_env_key(key))
+                })
+                .map(String::as_str)
+                .collect();
+            if !invalid.is_empty() {
+                eprintln!(
+                    "herdr-nvim: ignoring invalid sidebar.nvim_env entries: {} (each must be KEY=VALUE with an ASCII alphanumeric/_ key)",
+                    invalid.join(", ")
+                );
+            }
+            config
+        }
         Err(error) => {
             eprintln!(
                 "herdr-nvim: failed to parse config {}: {error} (using defaults)",
@@ -170,12 +228,16 @@ mod tests {
         let guard = ConfigEnvGuard::new();
         fs::write(
             &guard.path,
-            "[sidebar]\nnvim_bin = \"nvim-custom\"\nposition = \"bottom\"\n\n[picker]\nscan_lines = 500\nmax_files = 50\n",
+            "[sidebar]\nnvim_bin = \"nvim-custom\"\nnvim_env = [\"NVIM_APPNAME=myapp\", \"WEIRD=1\"]\nposition = \"bottom\"\n\n[picker]\nscan_lines = 500\nmax_files = 50\n",
         )
         .unwrap();
 
         let config = load();
         assert_eq!(config.sidebar.nvim_bin, "nvim-custom");
+        assert_eq!(
+            config.sidebar.env_override(),
+            vec![("NVIM_APPNAME", "myapp"), ("WEIRD", "1")]
+        );
         assert_eq!(config.sidebar.position, SidebarPosition::Bottom);
         assert_eq!(config.picker.scan_lines, 500);
         assert_eq!(config.picker.max_files, 50);
@@ -201,6 +263,25 @@ mod tests {
         let config = load();
         assert_eq!(config.picker.scan_lines, 500);
         assert_eq!(config.picker.max_files, 20);
+    }
+
+    #[test]
+    fn nvim_env_skips_malformed_entries() {
+        let side = Sidebar {
+            nvim_bin: "nvim".to_owned(),
+            nvim_env: vec![
+                "NVIM_APPNAME=myapp".to_owned(),
+                "no-equals-sign".to_owned(),
+                "BAD KEY=oops".to_owned(),
+                "path/never=valid".to_owned(),
+                "EMPTY=".to_owned(),
+            ],
+            position: SidebarPosition::Right,
+        };
+        assert_eq!(
+            side.env_override(),
+            vec![("NVIM_APPNAME", "myapp"), ("EMPTY", "")]
+        );
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -12,7 +12,7 @@ use std::{
 use anyhow::{bail, Context, Result};
 
 use crate::{
-    config::Config,
+    config::{Config, Sidebar},
     herdr::{CliHerdr, Herdr},
     state::{self, tab_key},
 };
@@ -40,12 +40,17 @@ pub fn socket_path(tab: &str) -> PathBuf {
     socket_dir().join(format!("{}.sock", tab_key(tab)))
 }
 
-/// Build a `Command` invoking the configured nvim binary. Shared by every
-/// call site that talks to a daemon (health checks, `--remote-ui` attach,
-/// `--remote-send` quit, `--remote` open) so `sidebar.nvim_bin` applies
-/// uniformly, not just to spawning the daemon itself.
-pub(crate) fn nvim_cmd(nvim_bin: &str) -> Command {
-    Command::new(nvim_bin)
+/// Build a `Command` invoking the configured nvim binary with the configured
+/// environment overrides. Shared by every call site that talks to a daemon
+/// (health checks, `--remote-ui` attach, `--remote-send` quit, `--remote`
+/// open) so both `sidebar.nvim_bin` and `sidebar.nvim_env` apply uniformly,
+/// not just to spawning the daemon itself.
+pub(crate) fn nvim_cmd(sidebar: &Sidebar) -> Command {
+    let mut command = Command::new(&sidebar.nvim_bin);
+    for (key, value) in sidebar.env_override() {
+        command.env(key, value);
+    }
+    command
 }
 
 /// Ensure a per-tab headless nvim daemon is listening on its socket,
@@ -58,7 +63,7 @@ pub fn ensure_daemon(
     cwd: &Path,
 ) -> Result<PathBuf> {
     let socket = socket_path(tab);
-    if daemon_healthy(&socket, &config.sidebar.nvim_bin) {
+    if daemon_healthy(&socket, &config.sidebar) {
         return Ok(socket);
     }
 
@@ -71,11 +76,11 @@ pub fn ensure_daemon(
     // only get here after the health check failed, so any file present is dead.
     remove_socket(&socket)?;
 
-    spawn_daemon(&socket, plugin_root, &config.sidebar.nvim_bin, cwd)?;
+    spawn_daemon(&socket, plugin_root, &config.sidebar, cwd)?;
 
     let deadline = Instant::now() + HEALTH_POLL_TIMEOUT;
     loop {
-        if daemon_healthy(&socket, &config.sidebar.nvim_bin) {
+        if daemon_healthy(&socket, &config.sidebar) {
             return Ok(socket);
         }
         if Instant::now() >= deadline {
@@ -88,11 +93,12 @@ pub fn ensure_daemon(
     }
 }
 
-fn spawn_daemon(socket: &Path, plugin_root: &Path, nvim_bin: &str, cwd: &Path) -> Result<()> {
-    // The pre-init `set rtp+=` below is not enough on its own: LazyVim (and any
-    // lazy.nvim config with the default `performance.rtp.reset = true`) rebuilds
-    // runtimepath from scratch during startup, dropping our appended path before
-    // VimEnter fires. So the VimEnter callback re-appends the plugin root to rtp
+fn spawn_daemon(socket: &Path, plugin_root: &Path, sidebar: &Sidebar, cwd: &Path) -> Result<()> {
+    // The pre-init `set rtp+=` below is not enough on its own: configs that
+    // rebuild runtimepath from scratch during startup (any plugin manager with
+    // an rtp reset, e.g. lazy.nvim's default `performance.rtp.reset = true`)
+    // drop our appended path before VimEnter fires. So the VimEnter callback
+    // re-appends the plugin root to rtp
     // *after* the user's config has loaded, then requires the plugin. The whole
     // thing stays wrapped in `pcall` so a missing/broken plugin never crashes
     // the daemon.
@@ -113,7 +119,7 @@ fn spawn_daemon(socket: &Path, plugin_root: &Path, nvim_bin: &str, cwd: &Path) -
     // teardown can no longer reach it.
     use std::os::unix::process::CommandExt;
 
-    let mut command = nvim_cmd(nvim_bin);
+    let mut command = nvim_cmd(sidebar);
     command
         .arg("--headless")
         .arg("--listen")
@@ -153,14 +159,14 @@ fn spawn_daemon(socket: &Path, plugin_root: &Path, nvim_bin: &str, cwd: &Path) -
     Ok(())
 }
 
-fn daemon_healthy(socket: &Path, nvim_bin: &str) -> bool {
-    remote_expr(socket, "1+1", nvim_bin).as_deref() == Some("2")
+fn daemon_healthy(socket: &Path, sidebar: &Sidebar) -> bool {
+    remote_expr(socket, "1+1", sidebar).as_deref() == Some("2")
 }
 
 /// Evaluate a vimscript expression on the daemon via `--remote-expr`, returning
 /// the trimmed stdout, or `None` if the daemon is unreachable.
-fn remote_expr(socket: &Path, expr: &str, nvim_bin: &str) -> Option<String> {
-    let output = nvim_cmd(nvim_bin)
+fn remote_expr(socket: &Path, expr: &str, sidebar: &Sidebar) -> Option<String> {
+    let output = nvim_cmd(sidebar)
         .arg("--server")
         .arg(socket)
         .arg("--remote-expr")
@@ -216,7 +222,7 @@ pub fn sidebar_cmd() -> Result<()> {
     let config = crate::config::load();
     let socket = ensure_daemon(&tab, &plugin_root, &config, Path::new(&cwd))?;
 
-    let error = nvim_cmd(&config.sidebar.nvim_bin)
+    let error = nvim_cmd(&config.sidebar)
         .arg("--server")
         .arg(&socket)
         .arg("--remote-ui")
@@ -247,12 +253,12 @@ pub(crate) fn plugin_root() -> Result<PathBuf> {
 pub fn gc_cmd() -> Result<()> {
     let mut herdr = CliHerdr;
     let config = crate::config::load();
-    gc(&mut herdr, &config.sidebar.nvim_bin)
+    gc(&mut herdr, &config.sidebar)
 }
 
 /// `pub(crate)` so `maneuver::toggle` can run an opportunistic, best-effort gc
 /// on every toggle to reap stale per-tab daemons from closed tabs.
-pub(crate) fn gc(h: &mut dyn Herdr, nvim_bin: &str) -> Result<()> {
+pub(crate) fn gc(h: &mut dyn Herdr, sidebar: &Sidebar) -> Result<()> {
     let dir = socket_dir();
     let entries = match fs::read_dir(&dir) {
         Ok(entries) => entries,
@@ -284,15 +290,15 @@ pub(crate) fn gc(h: &mut dyn Herdr, nvim_bin: &str) -> Result<()> {
         // `state::tab_key`), so it goes through `state::remove_key` rather
         // than `state::remove` -- that avoids sanitizing an already-sanitized
         // key a second time.
-        let _ = send_quit(&path, nvim_bin);
+        let _ = send_quit(&path, sidebar);
         remove_socket(&path)?;
         state::remove_key(tab_stem)?;
     }
     Ok(())
 }
 
-fn send_quit(socket: &Path, nvim_bin: &str) -> Result<()> {
-    nvim_cmd(nvim_bin)
+fn send_quit(socket: &Path, sidebar: &Sidebar) -> Result<()> {
+    nvim_cmd(sidebar)
         .arg("--server")
         .arg(socket)
         .arg("--remote-send")
@@ -395,9 +401,9 @@ mod tests {
 
     /// Best-effort daemon shutdown so no stray `nvim --headless` survives a test.
     fn stop_daemon(socket: &Path) {
-        let _ = send_quit(socket, "nvim");
+        let _ = send_quit(socket, &Sidebar::default());
         for _ in 0..50 {
-            if remote_expr(socket, "1+1", "nvim").is_none() {
+            if remote_expr(socket, "1+1", &Sidebar::default()).is_none() {
                 break;
             }
             sleep(Duration::from_millis(100));
@@ -434,15 +440,16 @@ mod tests {
             ensure_daemon("wD", &plugin_root, &config, &plugin_root).expect("first ensure_daemon");
         assert!(socket.exists(), "socket file should exist after spawn");
 
-        let pid1 = remote_expr(&socket, "getpid()", "nvim").expect("daemon should report a pid");
+        let pid1 =
+            remote_expr(&socket, "getpid()", &config.sidebar).expect("daemon should report a pid");
         assert!(!pid1.is_empty());
 
         let socket_again =
             ensure_daemon("wD", &plugin_root, &config, &plugin_root).expect("second ensure_daemon");
         assert_eq!(socket, socket_again);
 
-        let pid2 =
-            remote_expr(&socket, "getpid()", "nvim").expect("daemon should still report a pid");
+        let pid2 = remote_expr(&socket, "getpid()", &config.sidebar)
+            .expect("daemon should still report a pid");
         assert_eq!(
             pid1, pid2,
             "second ensure_daemon must reuse the daemon, not spawn a new one"
@@ -471,7 +478,7 @@ mod tests {
             list_tabs_results: VecDeque::from([Ok(vec!["wsKeep:t1".to_owned()])]),
             ..Default::default()
         };
-        gc(&mut herdr, "nvim").unwrap();
+        gc(&mut herdr, &Sidebar::default()).unwrap();
 
         assert!(socket_path("wsKeep:t1").exists(), "known tab kept");
         assert!(
@@ -484,5 +491,36 @@ mod tests {
             None => env::remove_var("HERDR_NVIM_STATE_DIR"),
         }
         drop(state_lock);
+    }
+
+    #[test]
+    fn nvim_cmd_applies_env_overrides_to_child() {
+        let sidebar = Sidebar::default();
+        let plain = nvim_cmd(&sidebar);
+        assert!(
+            plain.get_envs().all(|(key, _)| key != "NVIM_APPNAME"),
+            "default sidebar must not override the environment"
+        );
+
+        let sidebar = Sidebar {
+            nvim_env: vec![
+                "NVIM_APPNAME=myapp".to_owned(),
+                "HERDR_NVIM_EXTRA=1=2".to_owned(),
+                "garbage-entry".to_owned(), // malformed: filtered out by env_override
+            ],
+            ..Default::default()
+        };
+        let cmd = nvim_cmd(&sidebar);
+        let mut appname = None;
+        let mut extra = None;
+        for (key, value) in cmd.get_envs() {
+            match key.to_str() {
+                Some("NVIM_APPNAME") => appname = value.map(|v| v.to_string_lossy().into_owned()),
+                Some("HERDR_NVIM_EXTRA") => extra = value.map(|v| v.to_string_lossy().into_owned()),
+                _ => {}
+            }
+        }
+        assert_eq!(appname.as_deref(), Some("myapp"));
+        assert_eq!(extra.as_deref(), Some("1=2"), "value may contain an = sign");
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -48,10 +48,10 @@ pub fn doctor_cmd() -> Result<()> {
     env::set_var("HERDR_NVIM_STATE_DIR", &state_dir);
     // Belt-and-suspenders: even if a check panics or an early `?` fires, this
     // guard quits stray daemons and removes the temp dir on unwind.
-    let nvim_bin = crate::config::load().sidebar.nvim_bin;
+    let config = crate::config::load();
     let _temp_guard = TempGuard {
         dir: temp.clone(),
-        nvim_bin: nvim_bin.clone(),
+        sidebar: config.sidebar.clone(),
     };
 
     let mut herdr = CliHerdr;
@@ -66,7 +66,7 @@ pub fn doctor_cmd() -> Result<()> {
     println!();
     println!("--- cleanup ---");
     ws.close();
-    quit_daemons(&runtime_dir, &nvim_bin);
+    quit_daemons(&runtime_dir, &config.sidebar);
 
     let leftover = reap_leftover_nvim(&temp);
     println!("leaked headless nvim (temp {}): {leftover}", temp.display());
@@ -117,7 +117,7 @@ fn run_checks(h: &mut CliHerdr, ws: &str, with_agent: Option<&str>, fails: &mut 
             report(
                 fails,
                 "D-F19 remote-ui-attach",
-                check_f19(h, ws, &socket, &config.sidebar.nvim_bin),
+                check_f19(h, ws, &socket, &config.sidebar),
             );
         }
         Err(error) => {
@@ -236,18 +236,26 @@ fn check_f7(h: &mut CliHerdr, ws: &str) -> Result<String> {
 /// D-F19: attaching `nvim --remote-ui` to the daemon inside a scratch pane makes
 /// that pane display nvim. We prove it config-independently by driving the
 /// daemon to render a unique sentinel line, then reading it back from the pane.
-/// (Real user configs — e.g. LazyVim with `eob=" "` — hide the classic `~`
-/// end-of-buffer markers, so a sentinel is the robust marker.)
-fn check_f19(h: &mut CliHerdr, ws: &str, socket: &Path, nvim_bin: &str) -> Result<String> {
+/// (Real user configs — e.g. distro setups that restyle end-of-buffer
+/// markers via `eob=" "` — hide the classic `~`, so a sentinel is the robust
+/// marker.)
+fn check_f19(
+    h: &mut CliHerdr,
+    ws: &str,
+    socket: &Path,
+    sidebar: &crate::config::Sidebar,
+) -> Result<String> {
     let (_tab, pane) = h.create_tab(ws)?;
-    h.run_in_pane(
-        &pane,
-        &format!(
-            "exec {} --server {} --remote-ui",
-            daemon::shell_quote(nvim_bin),
-            socket.display()
-        ),
-    )?;
+    let mut attach = String::from("exec env");
+    for (key, value) in sidebar.env_override() {
+        attach.push_str(&format!(" {}={}", key, daemon::shell_quote(value)));
+    }
+    attach.push_str(&format!(
+        " {} --server {} --remote-ui",
+        daemon::shell_quote(&sidebar.nvim_bin),
+        socket.display()
+    ));
+    h.run_in_pane(&pane, &attach)?;
     // Let the remote UI attach before we drive it.
     sleep(Duration::from_millis(1500));
 
@@ -255,7 +263,7 @@ fn check_f19(h: &mut CliHerdr, ws: &str, socket: &Path, nvim_bin: &str) -> Resul
     nvim_remote_send(
         socket,
         &format!("<Esc><Cmd>enew<CR>i{sentinel}<Esc>"),
-        nvim_bin,
+        sidebar,
     )?;
 
     let mut content = String::new();
@@ -370,8 +378,8 @@ fn first_split_ratio(layout: &Value) -> Result<f64> {
         .context("pane layout missing result.layout.splits[0].ratio")
 }
 
-fn nvim_remote_send(socket: &Path, keys: &str, nvim_bin: &str) -> Result<()> {
-    let status = daemon::nvim_cmd(nvim_bin)
+fn nvim_remote_send(socket: &Path, keys: &str, sidebar: &crate::config::Sidebar) -> Result<()> {
+    let status = daemon::nvim_cmd(sidebar)
         .arg("--server")
         .arg(socket)
         .arg("--remote-send")
@@ -431,25 +439,25 @@ impl Drop for WorkspaceGuard {
 
 struct TempGuard {
     dir: PathBuf,
-    nvim_bin: String,
+    sidebar: crate::config::Sidebar,
 }
 
 impl Drop for TempGuard {
     fn drop(&mut self) {
-        quit_daemons(&self.dir.join("runtime"), &self.nvim_bin);
+        quit_daemons(&self.dir.join("runtime"), &self.sidebar);
         let _ = fs::remove_dir_all(&self.dir);
     }
 }
 
 /// Quit every headless nvim daemon whose socket lives in `runtime_dir`.
-fn quit_daemons(runtime_dir: &Path, nvim_bin: &str) {
+fn quit_daemons(runtime_dir: &Path, sidebar: &crate::config::Sidebar) {
     if let Ok(entries) = fs::read_dir(runtime_dir) {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.extension().and_then(OsStr::to_str) != Some("sock") {
                 continue;
             }
-            let _ = daemon::nvim_cmd(nvim_bin)
+            let _ = daemon::nvim_cmd(sidebar)
                 .arg("--server")
                 .arg(&path)
                 .arg("--remote-send")

--- a/src/maneuver.rs
+++ b/src/maneuver.rs
@@ -77,7 +77,7 @@ pub fn toggle(h: &mut dyn Herdr, ctx: &Ctx, sidebar_cmd: &str) -> Result<()> {
     // Opportunistic, best-effort gc: reap stale per-tab daemons left behind by
     // closed tabs. Non-fatal -- a gc failure must never block a toggle.
     let config = crate::config::load();
-    let _ = daemon::gc(h, &config.sidebar.nvim_bin);
+    let _ = daemon::gc(h, &config.sidebar);
 
     // Only a fully-Open sidebar is eligible for the fast close-and-return
     // path. A sidebar_pane recorded while phase is still Evacuating is a


### PR DESCRIPTION
New [sidebar] nvim_env = ["KEY=VALUE"] config surface, applied at the nvim_cmd chokepoint to every nvim variant the plugin spawns or attaches to (daemon, --remote-ui window, health probes, open-file clients, gc). The typical use is NVIM_APPNAME=myapp to run the sidebar under a custom nvim config instead of vanilla nvim.

- Config: parse + validate (bare alnum/_ keys only; malformed entries warn and are skipped rather than breaking the sidebar)
- Doctor F19 emits the env in its attach shell command too
- Tests: config parsing, malformed-entry filtering, env reaching the child
- Docs: README config block and a general NVIM_APPNAME paragraph