### PR TITLE
ci: enforce conventional commits via local hook and PR title lint

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Enforces Conventional Commits (https://www.conventionalcommits.org).
+# Installed via `just setup` -> git config core.hooksPath .githooks
+
+msg_file="$1"
+subject=$(head -n1 "$msg_file")
+
+# type(scope)!: subject   |   type: subject
+pattern='^(feat|fix|perf|refactor|docs|test|chore|ci|build|style|revert)(\([a-z0-9_-]+\))?!?: .+'
+
+if [[ "$subject" =~ ^Merge ]] || [[ "$subject" =~ ^Revert\  ]]; then
+  exit 0
+fi
+
+if ! [[ "$subject" =~ $pattern ]]; then
+  echo "commit-msg: not a Conventional Commit: \"$subject\"" >&2
+  echo "  expected: type(scope)?: subject   e.g. feat(picker): add fuzzy search" >&2
+  echo "  types: feat fix perf refactor docs test chore ci build style revert" >&2
+  exit 1
+fi

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,26 @@
+name: pr-title-lint
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+permissions:
+  pull-requests: read
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            test
+            chore
+            ci
+            build
+            style
+            revert

--- a/README.md
+++ b/README.md
@@ -152,3 +152,4 @@ did not start. Make sure that `sidebar.nvim_bin` points at a working nvim ≥
 ```sh
 just ci    # cargo fmt + cargo test + headless Lua suite
 ```
+test

--- a/justfile
+++ b/justfile
@@ -2,3 +2,6 @@ ci:
 	cargo fmt --check
 	cargo test
 	nvim --headless --noplugin -u NONE -l tests/run.lua
+
+setup:
+	git config core.hooksPath .githooks


### PR DESCRIPTION
Adds two enforcement layers so commit/PR messages stay Conventional-Commits-compliant for release-please:

1. `.githooks/commit-msg` — local hook, rejects non-conventional commit subjects. Wired via `just setup` (sets `core.hooksPath`).
2. `.github/workflows/pr-title-lint.yml` — CI backstop, lints the PR title (which becomes the squash-merge commit message).

Verified both layers manually: bad message/title rejected, good message/title accepted, in throwaway PR #9 (closed, not merged).