### PR TITLE
ci: trigger release build from release-please instead of tag push

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,5 +8,17 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.rp.outputs.releases_created }}
+      tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: rp
+  build:
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,17 @@
 name: release
 on:
-  push:
-    tags: ["v*"]
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag to build and attach binaries to (e.g. v0.2.1)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build and attach binaries to (e.g. v0.2.1)"
+        required: true
+        type: string
 permissions:
   contents: write
 jobs:
@@ -16,6 +26,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
       - uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
@@ -27,4 +39,5 @@ jobs:
       - run: cp target/${{ matrix.target }}/release/herdr-nvim herdr-nvim-${{ matrix.target }}
       - uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.tag }}
           files: herdr-nvim-${{ matrix.target }}


### PR DESCRIPTION
Fixes #14.

## Problem

`release.yml` was triggered by `on: push: tags`, but release-please pushes tags with the default `GITHUB_TOKEN`. GitHub does not start workflows from events created by `GITHUB_TOKEN`, so the build never ran. v0.2.0 and v0.2.1 have zero binaries and `herdr plugin install` 404s on machines without cargo.

## Fix

- `release.yml`: switch to `workflow_call` + `workflow_dispatch`, both taking a `tag` input. Checkout the tag and pass `tag_name` to the release step.
- `release-please.yml`: add a `build` job that calls `release.yml` when `releases_created == 'true'`.

## Backfill

After merge, run the `release` workflow manually with `tag: v0.2.1` to attach binaries to the existing release.