### PR TITLE
feat: skip agent picker when target is unambiguous

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,12 @@ uncapped.
 | --- | --- |
 | `<leader>ac` | comment the current line / visual selection |
 | `<leader>al` | list comments (float): hover to jump, `⏎` edit, `d` delete |
-| `<leader>as` | paste all comments into a chosen agent's input |
-| `<leader>aS` | send all comments to a chosen agent (auto-submits) |
+| `<leader>as` | paste all comments into the agent's input |
+| `<leader>aS` | send all comments to the agent (auto-submits) |
+
+Sending skips the picker when the target is obvious: the lone agent in the
+workspace, or the single agent sharing this tab (the sibling pane). The picker
+only appears when two or more agents could plausibly be meant.
 
 Comments are ephemeral by design: in-memory only, extmark-tracked (they follow
 your edits), cleared after a successful send. The sent prompt includes each

--- a/lua/herdr-nvim/agents.lua
+++ b/lua/herdr-nvim/agents.lua
@@ -17,6 +17,7 @@ function M.list(exec)
       table.insert(out, {
         pane_id = a.pane_id,
         workspace_id = a.workspace_id,
+        tab_id = a.tab_id,
         kind = a.agent or "unknown",
         status = a.agent_status or "unknown",
         cwd = a.cwd or "",
@@ -26,6 +27,25 @@ function M.list(exec)
   end
   table.sort(out, function(x, y) return x.title < y.title end)
   return out
+end
+
+-- Resolve the one agent to target without a picker, or nil when it's ambiguous.
+-- `list` is already workspace-scoped by M.list. Narrowest unambiguous match wins:
+--   1. a single agent sharing the current tab (HERDR_TAB_ID) — the sibling pane,
+--      same convention the file picker uses to find "the agent in this tab";
+--   2. otherwise, a lone agent in the workspace.
+-- Anything ambiguous (2+ candidates) returns nil so the caller shows the picker.
+function M.resolve(list)
+  if #list == 1 then return list[1] end
+  local tab = vim.env.HERDR_TAB_ID
+  if tab then
+    local in_tab = {}
+    for _, a in ipairs(list) do
+      if a.tab_id == tab then table.insert(in_tab, a) end
+    end
+    if #in_tab == 1 then return in_tab[1] end
+  end
+  return nil
 end
 
 function M.display(agent)

--- a/lua/herdr-nvim/init.lua
+++ b/lua/herdr-nvim/init.lua
@@ -109,7 +109,12 @@ function M.send_all(opts)
     vim.notify("herdr-nvim: " .. err, vim.log.levels.ERROR)
     return
   end
-  ui.pick_agent(agent_list, function(agent)
+  -- Single funnel for every send (both the resolved and picked paths), so the
+  -- "agent is working" warning lives in exactly one place.
+  local function deliver(agent)
+    if agent.status == "working" then
+      vim.notify("herdr-nvim: " .. agents.display(agent) .. " is working — sending anyway", vim.log.levels.WARN)
+    end
     local ok, derr = dispatch.send(agent.pane_id, text, opts)
     if not ok then
       vim.notify("herdr-nvim: " .. derr, vim.log.levels.ERROR)
@@ -121,7 +126,15 @@ function M.send_all(opts)
       end
     end
     vim.notify(string.format("herdr-nvim: sent %d comment(s) to %s", #list, agent.title))
-  end)
+  end
+  -- Skip the picker when the target is unambiguous (the common one-agent case);
+  -- fall back to the picker only when 2+ agents could plausibly be meant.
+  local agent = agents.resolve(agent_list)
+  if agent then
+    deliver(agent)
+  else
+    ui.pick_agent(agent_list, deliver)
+  end
 end
 
 function M.statusline()

--- a/lua/herdr-nvim/ui.lua
+++ b/lua/herdr-nvim/ui.lua
@@ -221,11 +221,10 @@ function M.pick_agent(agent_list, on_choice)
     vim.notify("herdr-nvim: no herdr agents found", vim.log.levels.WARN)
     return
   end
+  -- Pure selection: send-time policy (e.g. the "working" warning) lives in the
+  -- caller's on_choice, so both the picker and the auto-resolve path share it.
   vim.ui.select(agent_list, { prompt = "Send to agent", format_item = agents.display }, function(a)
     if a then
-      if a.status == "working" then
-        vim.notify("herdr-nvim: " .. agents.display(a) .. " is working — sending anyway", vim.log.levels.WARN)
-      end
       on_choice(a)
     end
   end)

--- a/tests/test_agents.lua
+++ b/tests/test_agents.lua
@@ -58,6 +58,44 @@ T.test("agents: unparseable JSON returns err", function()
   T.ok(err and err:match("unparseable"))
 end)
 
+T.test("agents: resolve returns the lone workspace agent", function()
+  local a = agents.resolve({ { pane_id = "wA:p1", tab_id = "wA:t1" } })
+  T.eq(a.pane_id, "wA:p1")
+end)
+
+T.test("agents: resolve picks the single agent in the current tab", function()
+  local previous = vim.env.HERDR_TAB_ID
+  vim.env.HERDR_TAB_ID = "wA:t2"
+  local a = agents.resolve({
+    { pane_id = "wA:p1", tab_id = "wA:t1" },
+    { pane_id = "wA:p2", tab_id = "wA:t2" },
+  })
+  vim.env.HERDR_TAB_ID = previous
+  T.eq(a.pane_id, "wA:p2")
+end)
+
+T.test("agents: resolve returns nil when the tab is ambiguous", function()
+  local previous = vim.env.HERDR_TAB_ID
+  vim.env.HERDR_TAB_ID = "wA:t1"
+  local a = agents.resolve({
+    { pane_id = "wA:p1", tab_id = "wA:t1" },
+    { pane_id = "wA:p2", tab_id = "wA:t1" },
+  })
+  vim.env.HERDR_TAB_ID = previous
+  T.eq(a, nil)
+end)
+
+T.test("agents: resolve returns nil when no tab context disambiguates", function()
+  local previous = vim.env.HERDR_TAB_ID
+  vim.env.HERDR_TAB_ID = nil
+  local a = agents.resolve({
+    { pane_id = "wA:p1", tab_id = "wA:t1" },
+    { pane_id = "wB:p2", tab_id = "wB:t1" },
+  })
+  vim.env.HERDR_TAB_ID = previous
+  T.eq(a, nil)
+end)
+
 T.test("agents: display row leads with agent kind", function()
   local row = agents.display({ kind = "pi", title = "π - a", status = "idle", cwd = "/x/y/proj" })
   T.eq(row, "pi · idle · proj")

--- a/tests/test_init.lua
+++ b/tests/test_init.lua
@@ -84,6 +84,84 @@ T.test("init: send_all formats, dispatches, clears", function()
   T.eq(comments.list(), {}, "clear_after_send default clears comments")
 end)
 
+T.test("init: send_all warns once when the resolved agent is working", function()
+  comments.clear()
+  local b = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(b, 0, -1, false, { "alpha" })
+  vim.api.nvim_buf_set_name(b, "/tmp/hn-send-working.lua")
+  comments.add(b, 1, 1, "check this")
+
+  local ui = require("herdr-nvim.ui")
+  local dispatch = require("herdr-nvim.dispatch")
+  local agents = require("herdr-nvim.agents")
+  local warns = {}
+  local o1, o2, o3, on = ui.pick_agent, dispatch.send, agents.list, vim.notify
+  ui.pick_agent = function() error("picker must not open for a lone agent") end
+  dispatch.send = function() return true end
+  agents.list = function() return { { pane_id = "wZ:p9", tab_id = "wZ:t1", kind = "pi", title = "pi", status = "working", cwd = "/x/y/z" } } end
+  vim.notify = function(msg, level) if level == vim.log.levels.WARN then table.insert(warns, msg) end end
+
+  hn.send_all({ submit = true })
+  ui.pick_agent, dispatch.send, agents.list, vim.notify = o1, o2, o3, on
+
+  T.eq(#warns, 1, "working warning must fire exactly once")
+  T.ok(warns[1]:find("is working", 1, true), "warning names the working state")
+end)
+
+T.test("init: send_all shows the picker when agents are ambiguous", function()
+  comments.clear()
+  local b = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(b, 0, -1, false, { "alpha" })
+  vim.api.nvim_buf_set_name(b, "/tmp/hn-send-multi.lua")
+  comments.add(b, 1, 1, "check this")
+
+  local ui = require("herdr-nvim.ui")
+  local dispatch = require("herdr-nvim.dispatch")
+  local agents = require("herdr-nvim.agents")
+  local previous = vim.env.HERDR_TAB_ID
+  vim.env.HERDR_TAB_ID = nil
+  local picked, sent = false, {}
+  local o1, o2, o3 = ui.pick_agent, dispatch.send, agents.list
+  ui.pick_agent = function(l, cb) picked = true; cb(l[1]) end
+  dispatch.send = function(pane) sent = { pane }; return true end
+  agents.list = function()
+    return {
+      { pane_id = "wA:p1", tab_id = "wA:t1", title = "pi", status = "idle" },
+      { pane_id = "wB:p2", tab_id = "wB:t1", title = "claude", status = "idle" },
+    }
+  end
+
+  hn.send_all({ submit = false })
+  ui.pick_agent, dispatch.send, agents.list = o1, o2, o3
+  vim.env.HERDR_TAB_ID = previous
+
+  T.ok(picked, "picker must open when the target is ambiguous")
+  T.eq(sent[1], "wA:p1")
+end)
+
+T.test("init: send_all skips the picker for a lone agent", function()
+  comments.clear()
+  local b = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(b, 0, -1, false, { "alpha" })
+  vim.api.nvim_buf_set_name(b, "/tmp/hn-send-solo.lua")
+  comments.add(b, 1, 1, "check this")
+
+  local ui = require("herdr-nvim.ui")
+  local dispatch = require("herdr-nvim.dispatch")
+  local agents = require("herdr-nvim.agents")
+  local picked, sent = false, {}
+  local o1, o2, o3 = ui.pick_agent, dispatch.send, agents.list
+  ui.pick_agent = function() picked = true end
+  dispatch.send = function(pane) sent = { pane }; return true end
+  agents.list = function() return { { pane_id = "wZ:p9", tab_id = "wZ:t1", title = "pi", status = "idle" } } end
+
+  hn.send_all({ submit = false })
+  ui.pick_agent, dispatch.send, agents.list = o1, o2, o3
+
+  T.ok(not picked, "picker must not open for a single unambiguous agent")
+  T.eq(sent[1], "wZ:p9")
+end)
+
 T.test("init: send_all retains comments when dispatch.send fails", function()
   comments.clear()
   local b = vim.api.nvim_create_buf(false, true)


### PR DESCRIPTION
## What

`as` (paste) and `aS` (send) no longer open the agent picker when the target is obvious. They now auto-resolve to:

1. the single agent sharing the current tab (`HERDR_TAB_ID`) — the sibling pane, same convention `prefix+o` uses; else
2. the lone agent in the workspace.

The picker only opens when 2+ agents could plausibly be meant. No config option (per the one-agent-per-workspace common case).

Closes #16.

## How

- `agents.lua` — capture `tab_id`; new pure `M.resolve(list)` returning an agent or `nil` (narrowest-match-first: tab → workspace → nil).
- `init.lua` — `send_all` calls `resolve`; dispatches directly or falls back to `ui.pick_agent`. The "agent is working — sending anyway" warning now lives once inside the shared `deliver` funnel.
- `ui.lua` — `pick_agent` is pure selection again; send-time policy moved to the caller's `on_choice`, shared by both paths.

## Tests

41/41 pass. New coverage: `resolve` (lone / tab-sibling / ambiguous-tab / no-tab-context), picker-shown-when-ambiguous, picker-skipped-for-lone, and warning-fires-once on the resolve path.

Verified against live herdr state: lone-workspace agent → picker skipped; 8 agents, no tab match → picker opens.