### PR TITLE
fix: fall back to HERDR_PLUGIN_CONTEXT_JSON when flat env vars are unset

### DIFF
--- a/lua/herdr-nvim/agents.lua
+++ b/lua/herdr-nvim/agents.lua
@@ -1,6 +1,26 @@
 local M = {}
 local exec_mod = require("herdr-nvim.exec")
 
+-- Plugin panes (sidebar/picker) only get workspace/tab context bundled as
+-- HERDR_PLUGIN_CONTEXT_JSON; plain terminal panes get flat HERDR_WORKSPACE_ID /
+-- HERDR_TAB_ID instead. Prefer the flat vars, fall back to decoding the JSON
+-- blob so resolve() works from either context.
+local function plugin_context()
+  local raw = vim.env.HERDR_PLUGIN_CONTEXT_JSON
+  if not raw then return {} end
+  local ok, decoded = pcall(vim.json.decode, raw)
+  if not ok or type(decoded) ~= "table" then return {} end
+  return decoded
+end
+
+local function current_workspace_id()
+  return vim.env.HERDR_WORKSPACE_ID or plugin_context().workspace_id
+end
+
+local function current_tab_id()
+  return vim.env.HERDR_TAB_ID or plugin_context().tab_id
+end
+
 function M.list(exec)
   exec = exec or exec_mod.default_exec
   local r = exec({ "herdr", "agent", "list" })
@@ -11,7 +31,7 @@ function M.list(exec)
   if not ok or type(decoded) ~= "table" then return nil, "herdr agent list: unparseable JSON" end
   local raw = (decoded.result or {}).agents or {}
   local out = {}
-  local here = vim.env.HERDR_WORKSPACE_ID
+  local here = current_workspace_id()
   for _, a in ipairs(raw) do
     if not here or a.workspace_id == here then
       table.insert(out, {
@@ -37,7 +57,7 @@ end
 -- Anything ambiguous (2+ candidates) returns nil so the caller shows the picker.
 function M.resolve(list)
   if #list == 1 then return list[1] end
-  local tab = vim.env.HERDR_TAB_ID
+  local tab = current_tab_id()
   if tab then
     local in_tab = {}
     for _, a in ipairs(list) do

--- a/tests/test_agents.lua
+++ b/tests/test_agents.lua
@@ -46,6 +46,36 @@ T.test("agents: current workspace excludes other workspaces", function()
   T.eq(list[1].pane_id, "wB:p2")
 end)
 
+T.test("agents: HERDR_PLUGIN_CONTEXT_JSON scopes workspace when flat var is unset", function()
+  local prev_flat, prev_json = vim.env.HERDR_WORKSPACE_ID, vim.env.HERDR_PLUGIN_CONTEXT_JSON
+  vim.env.HERDR_WORKSPACE_ID = nil
+  vim.env.HERDR_PLUGIN_CONTEXT_JSON = vim.json.encode({ workspace_id = "wB" })
+  local list = agents.list(fake_exec(fixture))
+  vim.env.HERDR_WORKSPACE_ID, vim.env.HERDR_PLUGIN_CONTEXT_JSON = prev_flat, prev_json
+  T.eq(#list, 1)
+  T.eq(list[1].pane_id, "wB:p2")
+end)
+
+T.test("agents: flat HERDR_WORKSPACE_ID wins over HERDR_PLUGIN_CONTEXT_JSON", function()
+  local prev_flat, prev_json = vim.env.HERDR_WORKSPACE_ID, vim.env.HERDR_PLUGIN_CONTEXT_JSON
+  vim.env.HERDR_WORKSPACE_ID = "wA"
+  vim.env.HERDR_PLUGIN_CONTEXT_JSON = vim.json.encode({ workspace_id = "wB" })
+  local list = agents.list(fake_exec(fixture))
+  vim.env.HERDR_WORKSPACE_ID, vim.env.HERDR_PLUGIN_CONTEXT_JSON = prev_flat, prev_json
+  T.eq(#list, 1)
+  T.eq(list[1].pane_id, "wA:p1")
+end)
+
+T.test("agents: malformed HERDR_PLUGIN_CONTEXT_JSON is ignored, not fatal", function()
+  local prev_flat, prev_json = vim.env.HERDR_WORKSPACE_ID, vim.env.HERDR_PLUGIN_CONTEXT_JSON
+  vim.env.HERDR_WORKSPACE_ID = nil
+  vim.env.HERDR_PLUGIN_CONTEXT_JSON = "not json"
+  local list, err = agents.list(fake_exec(fixture))
+  vim.env.HERDR_WORKSPACE_ID, vim.env.HERDR_PLUGIN_CONTEXT_JSON = prev_flat, prev_json
+  T.eq(err, nil)
+  T.eq(#list, 2) -- no valid workspace scope, so unscoped (same as no context at all)
+end)
+
 T.test("agents: CLI failure returns err", function()
   local list, err = agents.list(fake_exec("", 1))
   T.eq(list, nil)
@@ -83,6 +113,18 @@ T.test("agents: resolve returns nil when the tab is ambiguous", function()
   })
   vim.env.HERDR_TAB_ID = previous
   T.eq(a, nil)
+end)
+
+T.test("agents: resolve uses HERDR_PLUGIN_CONTEXT_JSON tab when flat var is unset", function()
+  local prev_flat, prev_json = vim.env.HERDR_TAB_ID, vim.env.HERDR_PLUGIN_CONTEXT_JSON
+  vim.env.HERDR_TAB_ID = nil
+  vim.env.HERDR_PLUGIN_CONTEXT_JSON = vim.json.encode({ workspace_id = "wA", tab_id = "wA:t2" })
+  local a = agents.resolve({
+    { pane_id = "wA:p1", tab_id = "wA:t1" },
+    { pane_id = "wA:p2", tab_id = "wA:t2" },
+  })
+  vim.env.HERDR_TAB_ID, vim.env.HERDR_PLUGIN_CONTEXT_JSON = prev_flat, prev_json
+  T.eq(a.pane_id, "wA:p2")
 end)
 
 T.test("agents: resolve returns nil when no tab context disambiguates", function()


### PR DESCRIPTION
## What

Fixes #20.

Plugin panes (the sidebar and the file picker) don't get `HERDR_WORKSPACE_ID` / `HERDR_TAB_ID` as plain env vars — herdr only bundles that context inside `HERDR_PLUGIN_CONTEXT_JSON` for panes launched as plugin actions. Plain terminal panes (a regular shell or nvim instance) get the flat vars instead.

`agents.lua` only ever checked the flat vars, so from inside a plugin pane:

- `M.list()`'s workspace filter never scoped anything (it always saw `nil` for "current workspace"), returning every agent across every open workspace.
- `M.resolve()`'s tab-matching branch never ran either, so with 2+ agents active anywhere, it always returned `nil` — the picker opened unconditionally, exactly the behavior #17 was meant to remove.

## How

- Added `plugin_context()` / `current_workspace_id()` / `current_tab_id()` helpers in `agents.lua`: prefer the flat env var, fall back to decoding `HERDR_PLUGIN_CONTEXT_JSON`, and degrade gracefully (empty table) on missing/malformed JSON.
- `M.list()` and `M.resolve()` now go through these helpers instead of reading `vim.env.HERDR_WORKSPACE_ID` / `vim.env.HERDR_TAB_ID` directly.

## Tests

45/45 pass (41 existing + 4 new):
- workspace scoping resolves from `HERDR_PLUGIN_CONTEXT_JSON` when the flat var is unset
- flat var still wins when both are present
- malformed JSON degrades to unscoped instead of erroring
- `resolve()`'s tab-matching also falls back to the JSON blob

Verified manually against a live herdr session with multiple workspaces open: picker was skipped correctly for a lone per-workspace agent from inside the sidebar's plugin pane, where it previously always appeared.