### PR TITLE
fix: skip already-owned maps on a second setup()

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ description = "open file from agent output"
 { "ChmaraX/herdr-nvim", opts = {} }
 ```
 
+The sidebar daemon also calls `setup()` on VimEnter. LazyVim rebuilds
+`runtimepath` during startup, so the daemon cannot rely on a `--cmd`
+inject. `{ opts = {} }` is enough: the second call skips maps it
+already owns. A map owned by another plugin is left alone, with a
+warning.
+
 ## The sidebar
 
 `prefix+e` toggles it. Each tab gets its own nvim, backed by a headless

--- a/lua/herdr-nvim/init.lua
+++ b/lua/herdr-nvim/init.lua
@@ -8,7 +8,13 @@ local ui = require("herdr-nvim.ui")
 M.config = { prefix = "<leader>a", keymaps = true, clear_after_send = true }
 
 local function map(mode, lhs, rhs, desc)
-  if vim.fn.maparg(vim.api.nvim_replace_termcodes(lhs, true, true, true), mode) ~= "" then
+  local existing = vim.fn.maparg(vim.api.nvim_replace_termcodes(lhs, true, true, true), mode, false, true)
+  if existing.lhs then
+    -- The sidebar daemon calls setup() on VimEnter after lazy.nvim already
+    -- did. Same desc means we own the map; do not warn about ourselves.
+    if existing.desc == desc then
+      return
+    end
     vim.notify("herdr-nvim: not overriding existing map " .. lhs, vim.log.levels.WARN)
     return
   end

--- a/tests/test_init.lua
+++ b/tests/test_init.lua
@@ -10,6 +10,20 @@ T.test("init: setup creates guarded keymaps", function()
   vim.keymap.del("n", " ac")
 end)
 
+T.test("init: a second setup does not warn about maps it already owns", function()
+  vim.g.mapleader = " "
+  local warns = {}
+  local orig = vim.notify
+  vim.notify = function(msg, level)
+    if level == vim.log.levels.WARN then table.insert(warns, msg) end
+  end
+  hn.setup({})
+  hn.setup({})
+  vim.notify = orig
+  T.eq(warns, {}, "second setup must not warn about its own maps")
+  T.ok(vim.fn.maparg(" al", "n") ~= "", "maps still present after the second setup")
+end)
+
 T.test("init: comment_line adds a decorated comment via stubbed input", function()
   comments.clear()
   local ui = require("herdr-nvim.ui")


### PR DESCRIPTION
## Why

Installing both halves, as the README already tells you to, calls `setup()` twice:

1. lazy.nvim via `{ opts = {} }`
2. the sidebar daemon on `VimEnter` (LazyVim resets `runtimepath`, so a `--cmd` inject would be dropped)

The second call then warned `herdr-nvim: not overriding existing map <leader>ac` (and the other annotation maps) about maps it had just set.

## What

- `setup()` skips a map it already owns (same `desc`); still warns and leaves a foreign map alone
- README now says `{ opts = {} }` is enough because of that second call
- regression test: two `setup()`s produce no warnings

## Test plan

- [x] `nvim --headless --noplugin -u NONE -l tests/run.lua` (42/42)
- [ ] Toggle the sidebar (`prefix+e` / custom prefix) with `{ "ChmaraX/herdr-nvim", opts = {} }` and confirm no `not overriding existing map` warnings