### PR TITLE
feat(picker)!: use fff-search as the default fuzzy engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,19 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,16 +31,133 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+dependencies = [
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
+
+[[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -55,6 +185,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
+name = "doxygen-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
+dependencies = [
+ "phf",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,10 +260,205 @@ dependencies = [
 ]
 
 [[package]]
+name = "fff-grep"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca0bd4b73cde171bf11165944fe7104af88fb5fc761fb355a469f7e0b18f7aa"
+dependencies = [
+ "bstr",
+ "memchr",
+]
+
+[[package]]
+name = "fff-notify-debouncer-full"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a4ebea7b8a2840cd59358bbf396f6f04313ce8eae84ac79703ce80298b8731"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "rustc-hash",
+ "walkdir",
+]
+
+[[package]]
+name = "fff-query-parser"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e476806b7e5999639b68970054c42d38d7fa430ea60118f67a05c0dd635fbd"
+
+[[package]]
+name = "fff-search"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fbb4c71c1d716fa1ddf7efbb7f62f5ef5a439110a4029c7dc743e54fe1e0417"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "blake3",
+ "dirs",
+ "dunce",
+ "fff-grep",
+ "fff-notify-debouncer-full",
+ "fff-query-parser",
+ "git2",
+ "glidesort",
+ "globset",
+ "heed",
+ "ignore",
+ "libc",
+ "memchr",
+ "memmap2",
+ "neo_frizbee",
+ "notify",
+ "parking_lot",
+ "pathdiff",
+ "rayon",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "signal-hook-registry",
+ "smallvec",
+ "thiserror 2.0.20",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
+name = "git2"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+]
+
+[[package]]
+name = "glidesort"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e102e6eb644d3e0b186fc161e4460417880a0a0b87d235f2e5b8fb30f2e9e0"
+
+[[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heed"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad82d6598ccf1dac15c8b758a1bd282b755b6776be600429176757190a1b0202"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "heed-traits",
+ "heed-types",
+ "libc",
+ "lmdb-master-sys",
+ "once_cell",
+ "page_size",
+ "serde",
+ "synchronoise",
+ "url",
+]
+
+[[package]]
+name = "heed-traits"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
+
+[[package]]
+name = "heed-types"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c255bdf46e07fb840d120a36dcc81f385140d7191c76a7391672675c01a55d"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "heed-traits",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "herdr-nvim"
@@ -82,10 +466,131 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "crossterm",
+ "fff-search",
  "regex",
  "serde",
  "serde_json",
  "toml",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b17771570a2b94107741a7b033f19132c2eee21d59d21b24d2ced26500bd66e"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -99,10 +604,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -111,10 +672,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.8+1.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
+name = "lmdb-master-sys"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaeb9bd22e73bd1babffff614994b341e9b2008de7bb73bf1f7e9154f1978f8b"
+dependencies = [
+ "cc",
+ "doxygen-rs",
+ "libc",
+]
 
 [[package]]
 name = "lock_api"
@@ -132,10 +743,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mio"
@@ -147,6 +776,97 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "neo_frizbee"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2f6120a8da26bea3587731072111062c5d8c51ca3a3a75a716bd8b735d5882"
+
+[[package]]
+name = "notify"
+version = "9.0.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7768eb7201a1964d8eb10224e850df046ab584ee3c3d26e340a993d81f748148"
+dependencies = [
+ "bitflags",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "objc2-core-foundation",
+ "objc2-core-services",
+ "walkdir",
+ "windows-sys 0.61.2",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-core-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583300ad934cba24ff5292aee751ecc070f7ca6b39a574cc21b7b5e588e06a0b"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -173,6 +893,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,12 +992,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -229,6 +1088,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +1104,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -274,7 +1148,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -298,6 +1172,21 @@ checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -331,10 +1220,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -345,6 +1263,115 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synchronoise"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dbc01390fc626ce8d1cffe3376ded2b72a11bb70e1c75f404a210e4daa4def2"
+dependencies = [
+ "crossbeam-queue",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -389,16 +1416,145 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.20",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -417,6 +1573,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,11 +1595,29 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -448,19 +1631,57 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -469,10 +1690,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -481,10 +1726,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -493,10 +1756,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -505,10 +1792,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -517,6 +1822,121 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,13 @@ serde_json = "1"
 toml = "0.8"
 anyhow = "1"
 crossterm = "0.28"
+# fff-search backend for the picker's fuzzy fallback tier. Users install
+# prebuilt release binaries, so the extra dependency weight is a CI/build
+# cost, not a user-facing one.
+fff-search = "0.10.6"
+
+[[example]]
+name = "fff_cold"
 
 [dev-dependencies]
 regex = "1"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ removes the daemons of closed tabs automatically.
   This includes every file that `git ls-files` reports, and it honors
   `.gitignore`. The match is on the path and filename, not the file contents.
 
+The repo-wide tier is served by [fff-search](https://crates.io/crates/fff-search)
+(fff.nvim's core matcher): multi-term queries (`cargo toml`), typo
+tolerance, and frecency ranking. If a fff.nvim frecency database exists at
+`~/.cache/nvim/fff_nvim`, the picker reuses it read-only (it copies the DB
+to a temp dir and opens the copy; your database is never opened, locked, or
+written) so files you actually open often rank higher. Set `frecency =
+false` to skip the DB reuse. The agent-touched session tier always ranks
+first and uses its own matcher regardless.
+
 Each row shows:
 
 - the path, relative to the agent's cwd
@@ -141,6 +150,7 @@ position = "right"   # right (default), left, top, or bottom
 scan_lines = 300    # pane lines scanned by the fallback text-scrape
 max_files = 20      # session entries shown before you type a query
                     # (a typed query fuzzy-searches the whole repo, uncapped)
+frecency = true     # let fff reuse ~/.cache/nvim/fff_nvim (read-only copy)
 ```
 
 ## Troubleshooting

--- a/examples/fff_cold.rs
+++ b/examples/fff_cold.rs
@@ -1,0 +1,91 @@
+//! Measures fff-search's cold per-invocation cost -- fresh process, no
+//! prior index, no warm cache -- on an arbitrary repo. The picker's popup
+//! is a fresh process per invocation (no resident index), so this is the
+//! number that determines whether that lifecycle is viable on a given repo
+//! size. See docs/fff-picker.md for measured results.
+//!
+//! Run: `cargo run --release --example fff_cold -- /path/to/big/repo [query]`
+
+use std::time::{Duration, Instant};
+
+use fff_search::file_picker::FilePicker;
+use fff_search::frecency::FrecencyTracker;
+use fff_search::{
+    FFFMode, FilePickerOptions, FuzzySearchOptions, PaginationArgs, QueryParser, SharedFilePicker,
+    SharedFrecency,
+};
+
+fn main() -> anyhow::Result<()> {
+    let mut args = std::env::args().skip(1);
+    let root = args.next().unwrap_or_else(|| ".".to_owned());
+    let query_str = args.next().unwrap_or_else(|| "picker".to_owned());
+
+    let t_process = Instant::now();
+
+    // Frecency DB: throwaway temp dir (cost included -- a real cold popup
+    // would open one too, or skip it entirely).
+    let tmp = std::env::temp_dir().join(format!("fff-cold-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp)?;
+
+    let t0 = Instant::now();
+    let shared_picker = SharedFilePicker::default();
+    let shared_frecency = SharedFrecency::default();
+    let frecency = FrecencyTracker::open(tmp.join("frecency"))?;
+    shared_frecency.init(frecency)?;
+    let setup_elapsed = t0.elapsed();
+
+    let t0 = Instant::now();
+    FilePicker::new_with_shared_state(
+        shared_picker.clone(),
+        shared_frecency.clone(),
+        FilePickerOptions {
+            base_path: root.clone().into(),
+            mode: FFFMode::Ai,
+            watch: false,
+            ..Default::default()
+        },
+    )?;
+    if !shared_picker.wait_for_scan(Duration::from_secs(60)) {
+        anyhow::bail!("scan did not finish within 60s");
+    }
+    let scan_elapsed = t0.elapsed();
+
+    let guard = shared_picker.read().map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    let picker = guard.as_ref().unwrap();
+    let file_count = picker.live_file_count();
+
+    let parser = QueryParser::default();
+    let query = parser.parse(&query_str);
+    let t0 = Instant::now();
+    let results = picker.fuzzy_search(
+        &query,
+        None,
+        FuzzySearchOptions {
+            max_threads: 0,
+            current_file: None,
+            pagination: PaginationArgs {
+                offset: 0,
+                limit: 8,
+            },
+            ..Default::default()
+        },
+    );
+    let query_elapsed = t0.elapsed();
+
+    println!("repo:            {root}");
+    println!("indexed files:   {file_count}");
+    println!("frecency setup:  {setup_elapsed:?}");
+    println!("scan + index:    {scan_elapsed:?}");
+    println!(
+        "query {query_str:?}: {} matches in {query_elapsed:?}",
+        results.total_matched
+    );
+    for item in results.items.iter().take(5) {
+        println!("  {}", item.relative_path(picker));
+    }
+    println!("TOTAL cold (setup+scan+query): {:?}", t_process.elapsed());
+
+    drop(guard);
+    std::fs::remove_dir_all(&tmp).ok();
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,6 +59,10 @@ pub struct Picker {
     /// list, not just this capped default view.
     #[serde(default = "default_max_files")]
     pub max_files: u32,
+    /// Reuse an existing fff.nvim frecency database (`~/.cache/nvim/fff_nvim`)
+    /// for ranking, read-only via a temp copy.
+    #[serde(default = "default_true")]
+    pub frecency: bool,
 }
 
 impl Default for Picker {
@@ -66,6 +70,7 @@ impl Default for Picker {
         Self {
             scan_lines: default_scan_lines(),
             max_files: default_max_files(),
+            frecency: true,
         }
     }
 }
@@ -76,6 +81,10 @@ fn default_scan_lines() -> u32 {
 
 fn default_max_files() -> u32 {
     20
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// Path to the config file. `HERDR_NVIM_CONFIG` overrides everything (used by
@@ -223,5 +232,22 @@ mod tests {
 
         let config = load();
         assert_eq!(config, Config::default());
+    }
+
+    #[test]
+    fn frecency_defaults_to_on() {
+        let _guard = ConfigEnvGuard::new();
+
+        let config = load();
+        assert!(config.picker.frecency);
+    }
+
+    #[test]
+    fn frecency_can_be_disabled() {
+        let guard = ConfigEnvGuard::new();
+        fs::write(&guard.path, "[picker]\nfrecency = false\n").unwrap();
+
+        let config = load();
+        assert!(!config.picker.frecency);
     }
 }

--- a/src/fff.rs
+++ b/src/fff.rs
@@ -1,0 +1,175 @@
+//! fff-search backend for the picker's fuzzy fallback tier.
+//!
+//! [`FffIndex::open`] starts an fff-search scan of the workspace; by the
+//! first keystroke the index is warm. [`FffIndex::search`] returns ranked
+//! repo-relative hits with match highlight spans.
+//!
+//! Frecency reuse is read-only: `~/.cache/nvim/fff_nvim` is copied to a
+//! temp dir before opening, since `FrecencyTracker::open` writes
+//! (garbage-collects) on open.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use fff_search::file_picker::FilePicker;
+use fff_search::frecency::FrecencyTracker;
+use fff_search::{
+    FFFMode, FilePickerOptions, FuzzySearchOptions, PaginationArgs, QueryParser, SharedFilePicker,
+    SharedFrecency,
+};
+
+/// One ranked hit from the fff tier: the absolute path of the file and
+/// byte-offset highlight spans **into its workspace-relative path** (which
+/// is exactly what the picker displays for files under the workspace cwd).
+pub struct FffHit {
+    pub path: String,
+    pub highlights: Vec<(usize, usize)>,
+}
+
+/// Cap on hits pulled from fff per keystroke. The overlay viewport shows
+/// ~a dozen rows; 100 leaves plenty of scroll depth without ferrying
+/// thousands of matches per keystroke.
+const PAGE_LIMIT: usize = 100;
+
+/// How long `search` will wait for the initial background scan. The scan
+/// runs concurrently with the user reading/typing, so this is almost
+/// always already satisfied; the bound only guards degenerate cases
+/// (enormous cold trees, slow disks).
+const SCAN_WAIT: Duration = Duration::from_secs(3);
+
+pub struct FffIndex {
+    shared: SharedFilePicker,
+    cwd: String,
+    /// Temp dir holding the frecency-DB copy (and/or scratch DB); removed
+    /// on drop.
+    tmp: Option<PathBuf>,
+}
+
+impl FffIndex {
+    /// Start indexing `cwd`. Returns `None` (the caller leaves the fuzzy
+    /// fallback tier empty for this popup) if fff can't be set up.
+    /// `use_frecency` (config `[picker] frecency`, default true) gates the
+    /// fff.nvim frecency-DB reuse; ranking works without it.
+    pub fn open(cwd: &str, use_frecency: bool) -> Option<Self> {
+        let shared = SharedFilePicker::default();
+        let shared_frecency = SharedFrecency::default();
+
+        // Read-only use of the user's fff.nvim frecency: copy, then open
+        // the copy. Never open the user's DB directly (open() GCs = writes).
+        let mut tmp = None;
+        if use_frecency {
+            if let Some((tracker, dir)) = open_frecency_copy() {
+                if shared_frecency.init(tracker).is_ok() {
+                    tmp = Some(dir);
+                }
+            }
+        }
+
+        FilePicker::new_with_shared_state(
+            shared.clone(),
+            shared_frecency,
+            FilePickerOptions {
+                base_path: cwd.into(),
+                mode: FFFMode::Ai,
+                watch: false,
+                ..Default::default()
+            },
+        )
+        .ok()?;
+
+        Some(Self {
+            shared,
+            cwd: cwd.to_owned(),
+            tmp,
+        })
+    }
+
+    /// Ranked fff hits for `query`, in fff's own score order. Empty on
+    /// any failure (scan timeout, lock poison) -- the caller treats that
+    /// as "no extra tier".
+    pub fn search(&self, query: &str) -> Vec<FffHit> {
+        if !self.shared.wait_for_scan(SCAN_WAIT) {
+            return Vec::new();
+        }
+        let Ok(guard) = self.shared.read() else {
+            return Vec::new();
+        };
+        let Some(picker) = guard.as_ref() else {
+            return Vec::new();
+        };
+        let parsed = QueryParser::default().parse(query);
+        let results = picker.fuzzy_search(
+            &parsed,
+            None,
+            FuzzySearchOptions {
+                max_threads: 0,
+                current_file: None,
+                pagination: PaginationArgs {
+                    offset: 0,
+                    limit: PAGE_LIMIT,
+                },
+                ..Default::default()
+            },
+        );
+        results
+            .items
+            .iter()
+            .zip(results.match_byte_offsets.iter())
+            .map(|(item, offsets)| {
+                let rel = item.relative_path(picker);
+                FffHit {
+                    path: format!("{}/{rel}", self.cwd.trim_end_matches('/')),
+                    highlights: offsets
+                        .iter()
+                        .map(|&(s, e)| (s as usize, e as usize))
+                        .collect(),
+                }
+            })
+            .collect()
+    }
+}
+
+impl Drop for FffIndex {
+    fn drop(&mut self) {
+        if let Some(tmp) = self.tmp.take() {
+            let _ = std::fs::remove_dir_all(tmp);
+        }
+    }
+}
+
+/// Copy `~/.cache/nvim/fff_nvim` (fff.nvim's default frecency DB) to a
+/// temp dir and open the copy. Returns `None` when the DB doesn't exist
+/// or anything fails; a torn copy (fff.nvim writing mid-copy) fails the
+/// open and lands here too.
+fn open_frecency_copy() -> Option<(FrecencyTracker, PathBuf)> {
+    let home = std::env::var("HOME").ok()?;
+    let src = Path::new(&home).join(".cache/nvim/fff_nvim");
+    if !src.is_dir() {
+        return None;
+    }
+    let tmp = std::env::temp_dir().join(format!("herdr-nvim-fff-{}", std::process::id()));
+    if copy_dir(&src, &tmp).is_err() {
+        let _ = std::fs::remove_dir_all(&tmp);
+        return None;
+    }
+    match FrecencyTracker::open(&tmp) {
+        Ok(tracker) => Some((tracker, tmp)),
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&tmp);
+            None
+        }
+    }
+}
+
+/// Shallow copy of the LMDB env dir (data.mdb + lock.mdb; the DB is
+/// capped at ~10MiB by fff-search, so this is a few ms at worst).
+fn copy_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        if entry.file_type()?.is_file() {
+            std::fs::copy(entry.path(), dst.join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod daemon;
 mod doctor;
 mod extract;
+mod fff;
 mod gitscan;
 mod herdr;
 mod layout;

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -10,7 +10,7 @@
 //! capped to `handoff.max_files`; the moment the user types, matching widens
 //! to every candidate (including the repo-wide pool the bridge appended) and
 //! is ranked by a fuzzy score. The pure halves (`fuzzy_match`, `display_path`,
-//! `ellipsize_prefix`, `compute_matches`, `visible_count`, `scroll_window`,
+//! `ellipsize_prefix`, `default_view`, `visible_count`, `scroll_window`,
 //! `fmt_age`) are unit tested; the interactive loop and `render` are exercised
 //! live.
 
@@ -32,6 +32,7 @@ use crossterm::{
 use serde::{Deserialize, Serialize};
 
 use crate::candidates::Candidate;
+use crate::fff::{FffHit, FffIndex};
 
 /// Environment variable holding the path to the handoff JSON file.
 const HANDOFF_ENV: &str = "HERDR_NVIM_HANDOFF";
@@ -193,28 +194,32 @@ pub fn fmt_age(now: u64, then: u64) -> String {
     }
 }
 
-/// Build the ranked match list for `query` over `cands` (with precomputed
-/// `displays`). Empty query -> only session candidates, in their given
-/// (recency) order, unscored. Non-empty query -> fuzzy over *every* candidate,
-/// sorted by score descending then original index (which preserves recency and
-/// keeps session entries ahead of equally-scored repo-only ones). Pure, unit
-/// tested.
-pub fn compute_matches(cands: &[Candidate], displays: &[String], query: &str) -> Vec<FilterMatch> {
-    if query.is_empty() {
-        return cands
-            .iter()
-            .enumerate()
-            .filter(|(_, c)| c.session)
-            .map(|(index, _)| FilterMatch {
-                index,
-                score: 0,
-                highlights: Vec::new(),
-            })
-            .collect();
-    }
+/// The default (empty-query) view: only session candidates, in their given
+/// (recency) order, unscored. Pure, unit tested.
+pub fn default_view(cands: &[Candidate]) -> Vec<FilterMatch> {
+    cands
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| c.session)
+        .map(|(index, _)| FilterMatch {
+            index,
+            score: 0,
+            highlights: Vec::new(),
+        })
+        .collect()
+}
+
+/// Fuzzy-rank only the session (agent-touched) candidates for `query`.
+/// Always the first tier shown; the fff backend supplies the fallback tier.
+pub fn session_tier_matches(
+    cands: &[Candidate],
+    displays: &[String],
+    query: &str,
+) -> Vec<FilterMatch> {
     let mut matches: Vec<FilterMatch> = displays
         .iter()
         .enumerate()
+        .filter(|(index, _)| cands[*index].session)
         .filter_map(|(index, display)| {
             fuzzy_match(display, query).map(|(score, highlights)| FilterMatch {
                 index,
@@ -225,6 +230,62 @@ pub fn compute_matches(cands: &[Candidate], displays: &[String], query: &str) ->
         .collect();
     matches.sort_by(|a, b| b.score.cmp(&a.score).then(a.index.cmp(&b.index)));
     matches
+}
+
+/// Append the fff repo-wide tier after the session tier, resolving each hit
+/// to its candidate index by path. Hits already in the session tier are
+/// dropped (agent tier wins); hits outside the candidate pool are skipped
+/// (the handoff protocol is index-based). Highlight spans are kept only when
+/// they land on char boundaries of the display string, otherwise dropped.
+pub fn merge_fff_tier(
+    cands: &[Candidate],
+    displays: &[String],
+    session: Vec<FilterMatch>,
+    fff_hits: Vec<FffHit>,
+) -> Vec<FilterMatch> {
+    use std::collections::{HashMap, HashSet};
+
+    let by_path: HashMap<&str, usize> = cands
+        .iter()
+        .enumerate()
+        .map(|(i, c)| (c.path.as_str(), i))
+        .collect();
+    let taken: HashSet<usize> = session.iter().map(|m| m.index).collect();
+
+    let mut out = session;
+    for hit in fff_hits {
+        let Some(&index) = by_path.get(hit.path.as_str()) else {
+            continue;
+        };
+        if taken.contains(&index) {
+            continue;
+        }
+        let display = &displays[index];
+        let spans_ok = hit.highlights.iter().all(|&(s, e)| {
+            s < e
+                && e <= display.len()
+                && display.is_char_boundary(s)
+                && display.is_char_boundary(e)
+        });
+        out.push(FilterMatch {
+            index,
+            score: 0,
+            highlights: if spans_ok { hit.highlights } else { Vec::new() },
+        });
+    }
+    out
+}
+
+/// Ranked matches for a non-empty `query`: session candidates first, then
+/// the fff backend's repo-wide results appended and deduped.
+pub fn compute_matches_fff(
+    cands: &[Candidate],
+    displays: &[String],
+    query: &str,
+    fff: &FffIndex,
+) -> Vec<FilterMatch> {
+    let session = session_tier_matches(cands, displays, query);
+    merge_fff_tier(cands, displays, session, fff.search(query))
 }
 
 /// How many matches the view shows: capped to `max_files` when `query` is
@@ -269,12 +330,19 @@ pub fn picker_cmd() -> Result<()> {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
+    // `None` on init failure leaves the fuzzy fallback tier empty.
+    let config = crate::config::load();
+    let fff = FffIndex::open(&handoff.cwd, config.picker.frecency);
+    if fff.is_none() {
+        eprintln!("herdr-nvim: fff index failed to initialize; fuzzy fallback tier is empty");
+    }
     if let Some(chosen) = run_overlay(
         &handoff.candidates,
         &handoff.cwd,
         home.as_deref(),
         handoff.max_files,
         now,
+        fff.as_ref(),
     )? {
         handoff.chosen = Some(chosen);
         let encoded = serde_json::to_string(&handoff)?;
@@ -316,6 +384,7 @@ fn run_overlay(
     home: Option<&str>,
     max_files: u32,
     now: u64,
+    fff: Option<&FffIndex>,
 ) -> Result<Option<usize>> {
     if cands.is_empty() {
         return Ok(None);
@@ -332,7 +401,11 @@ fn run_overlay(
     let mut cursor = 0usize;
 
     loop {
-        let matches = compute_matches(cands, &displays, &query);
+        let matches = match (fff, query.is_empty()) {
+            (_, true) => default_view(cands),
+            (Some(index), false) => compute_matches_fff(cands, &displays, &query, index),
+            (None, false) => session_tier_matches(cands, &displays, &query),
+        };
         let shown = visible_count(matches.len(), &query, max_files);
         let visible = &matches[..shown];
         if cursor >= visible.len() {
@@ -785,31 +858,21 @@ mod tests {
         }
     }
 
-    // --- compute_matches --------------------------------------------------
+    // --- default_view / session_tier_matches -------------------------------
 
     #[test]
     fn empty_query_shows_only_session_candidates() {
         let cands = vec![cand("/r/a.rs"), repo_cand("/r/b.rs")];
-        let displays = displays_of(&cands, "/r");
-        let m = compute_matches(&cands, &displays, "");
+        let m = default_view(&cands);
         assert_eq!(m.len(), 1, "repo-only candidates hidden from default view");
         assert_eq!(m[0].index, 0);
-    }
-
-    #[test]
-    fn typed_query_searches_repo_candidates_too() {
-        let cands = vec![cand("/r/a.rs"), repo_cand("/r/deep/target.rs")];
-        let displays = displays_of(&cands, "/r");
-        let m = compute_matches(&cands, &displays, "target");
-        assert_eq!(m.len(), 1);
-        assert_eq!(m[0].index, 1, "repo file reachable once the user types");
     }
 
     #[test]
     fn matches_sorted_by_score_desc() {
         let cands = vec![cand("/r/domain/other.rs"), cand("/r/src/main.rs")];
         let displays = displays_of(&cands, "/r");
-        let m = compute_matches(&cands, &displays, "main");
+        let m = session_tier_matches(&cands, &displays, "main");
         // main.rs (filename hit) must rank before domain/ (dir hit).
         assert_eq!(m[0].index, 1);
     }
@@ -818,7 +881,7 @@ mod tests {
     fn equal_score_breaks_toward_lower_index_recency() {
         let cands = vec![cand("/r/a/x.rs"), cand("/r/b/x.rs")];
         let displays = displays_of(&cands, "/r");
-        let m = compute_matches(&cands, &displays, "x.rs");
+        let m = session_tier_matches(&cands, &displays, "x.rs");
         assert_eq!(m[0].index, 0, "ties keep original (recency) order");
     }
 
@@ -905,5 +968,134 @@ mod tests {
         let (first, count) = scroll_window(19, 20, 5);
         assert_eq!(first, 15);
         assert_eq!(count, 5);
+    }
+
+    // --- merge_fff_tier ---------------------------------------------------
+
+    fn hit(path: &str, highlights: Vec<(usize, usize)>) -> FffHit {
+        FffHit {
+            path: path.into(),
+            highlights,
+        }
+    }
+
+    #[test]
+    fn fff_tier_appends_after_session_tier() {
+        let cands = vec![cand("/r/touched.rs"), repo_cand("/r/repo_only.rs")];
+        let displays = displays_of(&cands, "/r");
+        let session = session_tier_matches(&cands, &displays, "rs");
+        assert_eq!(session.len(), 1, "session tier only ranks session cands");
+        let merged = merge_fff_tier(
+            &cands,
+            &displays,
+            session,
+            vec![hit("/r/repo_only.rs", vec![(0, 2)])],
+        );
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].index, 0, "agent tier always first");
+        assert_eq!(merged[1].index, 1);
+    }
+
+    #[test]
+    fn fff_hits_for_session_matched_paths_are_deduped() {
+        let cands = vec![cand("/r/touched.rs")];
+        let displays = displays_of(&cands, "/r");
+        let session = session_tier_matches(&cands, &displays, "touched");
+        let merged = merge_fff_tier(
+            &cands,
+            &displays,
+            session,
+            vec![hit("/r/touched.rs", vec![(0, 7)])],
+        );
+        assert_eq!(merged.len(), 1, "no duplicate row for an agent-tier path");
+        assert_eq!(merged[0].index, 0);
+    }
+
+    #[test]
+    fn fff_hit_rescues_session_path_the_builtin_matcher_missed() {
+        // The built-in matcher can't do multi-term; fff can.
+        let cands = vec![cand("/r/cargo/config.toml")];
+        let displays = displays_of(&cands, "/r");
+        let session = session_tier_matches(&cands, &displays, "cargo toml");
+        assert!(session.is_empty(), "builtin matcher can't do multi-term");
+        let merged = merge_fff_tier(
+            &cands,
+            &displays,
+            session,
+            vec![hit("/r/cargo/config.toml", vec![(0, 5)])],
+        );
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].index, 0);
+    }
+
+    #[test]
+    fn fff_hits_outside_the_candidate_pool_are_skipped() {
+        let cands = vec![cand("/r/a.rs")];
+        let displays = displays_of(&cands, "/r");
+        let merged = merge_fff_tier(
+            &cands,
+            &displays,
+            Vec::new(),
+            vec![hit("/r/not_in_handoff.rs", vec![])],
+        );
+        assert!(merged.is_empty(), "index-based handoff can't represent it");
+    }
+
+    #[test]
+    fn fff_bad_highlight_spans_are_dropped_not_rendered() {
+        let cands = vec![repo_cand("/r/a.rs")];
+        let displays = displays_of(&cands, "/r"); // display "a.rs", 4 bytes
+        let merged = merge_fff_tier(
+            &cands,
+            &displays,
+            Vec::new(),
+            vec![hit("/r/a.rs", vec![(0, 99)])],
+        );
+        assert_eq!(merged.len(), 1);
+        assert!(
+            merged[0].highlights.is_empty(),
+            "out-of-range spans dropped, row kept"
+        );
+    }
+
+    /// Indexes this repo through the real fff backend and checks the tier
+    /// contract: agent tier first, results resolved to candidate indices, deduped.
+    #[test]
+    fn fff_end_to_end_over_this_repo() {
+        let cwd = env!("CARGO_MANIFEST_DIR").to_owned();
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&cwd)
+            .arg("ls-files")
+            .output()
+            .expect("git ls-files");
+        // Session tier: picker.rs itself. Repo tier: everything tracked.
+        let mut cands = vec![cand(&format!("{cwd}/src/picker.rs"))];
+        for line in String::from_utf8_lossy(&out.stdout).lines() {
+            let abs = format!("{cwd}/{line}");
+            if abs != cands[0].path {
+                cands.push(repo_cand(&abs));
+            }
+        }
+        let displays = displays_of(&cands, &cwd);
+        let fff = FffIndex::open(&cwd, true).expect("fff index should open");
+
+        let matches = compute_matches_fff(&cands, &displays, "picker", &fff);
+        assert!(!matches.is_empty(), "fff found nothing for 'picker'");
+        assert_eq!(
+            matches[0].index, 0,
+            "agent-touched src/picker.rs must rank first"
+        );
+        let mut seen = std::collections::HashSet::new();
+        for m in &matches {
+            assert!(seen.insert(m.index), "duplicate candidate in results");
+        }
+
+        // Multi-term query the built-in matcher can't do at all.
+        let multi = compute_matches_fff(&cands, &displays, "cargo toml", &fff);
+        assert!(
+            multi.iter().any(|m| displays[m.index] == "Cargo.toml"),
+            "multi-term 'cargo toml' should surface Cargo.toml via fff"
+        );
     }
 }


### PR DESCRIPTION
Closes #24.

## Summary

The picker's fuzzy fallback tier (repo-wide search, used when the agent-touched session tier doesn't have what you want) now runs on [fff-search](https://crates.io/crates/fff-search), fff.nvim's core matching crate, as its only matcher.

- **Required dependency, no feature flag, no runtime choice.** Users install prebuilt release binaries, so the added dependencies are a CI/build cost, not a user-facing one.
- **A failed fff init doesn't break anything.** If it can't initialize (bad cwd, corrupted frecency copy, an unexpected error), the fuzzy fallback tier is simply empty for that popup — one stderr line, no crash. The agent-touched session tier (its own matcher, unaffected) still ranks first regardless.
- **Frecency reuse:** if `~/.cache/nvim/fff_nvim` exists, it's copied to a temp dir and the copy opened read-only, so ranking benefits from the user's real fff.nvim history without ever touching their DB (`FrecencyTracker::open` GCs on open, i.e. writes). `[picker] frecency = false` disables this.
- Fixes a latent bug along the way: the old matcher treated spaces literally, so `"cargo toml"` matched nothing. fff's query parser AND-matches whitespace-split terms.

## Testing

144 tests pass, release build clean.
