### PR TITLE
feat(lua): add :Herdr command + Lua API for annotations (non-breaking)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/
 /bin/
 /target/
 nvim.log
+doc/tags

--- a/README.md
+++ b/README.md
@@ -96,12 +96,27 @@ uncapped.
 
 ## Annotations
 
-| Mapping | Action |
-| --- | --- |
-| `<leader>ac` | comment the current line / visual selection |
-| `<leader>al` | list comments (float): hover to jump, `⏎` edit, `d` delete |
-| `<leader>as` | paste all comments into the agent's input |
-| `<leader>aS` | send all comments to the agent (auto-submits) |
+Each action has a default keymap and a `:Herdr` subcommand (subcommands
+tab-complete):
+
+| Keymap | Command | Action |
+| --- | --- | --- |
+| `<leader>ac` | `:Herdr comment` | comment the current line / selection (the command also takes a range: `:5,10Herdr comment`) |
+| `<leader>al` | `:Herdr list` | list comments (float): hover to jump, `⏎` edit, `d` delete |
+| `<leader>as` | `:Herdr send` | paste all comments into the agent's input |
+| `<leader>aS` | `:Herdr submit` | send all comments to the agent (auto-submits) |
+
+Keymaps are on by default (prefix `<leader>a`) and never override a map you
+already set. To bind your own, set `keymaps = false` and map the command:
+
+```lua
+require("herdr-nvim").setup({ keymaps = false })
+vim.keymap.set({ "n", "x" }, "<leader>ac", "<CMD>Herdr comment<CR>", { desc = "Comment" })
+```
+
+Or call the Lua API directly (`comment_line`, `comment_selection`,
+`comment_range(s, e)`, `list_comments`, `send_all{ submit = false|true }`).
+See `:help herdr-nvim` for the full reference.
 
 Sending skips the picker when the target is obvious: the lone agent in the
 workspace, or the single agent sharing this tab (the sibling pane). The picker
@@ -112,8 +127,7 @@ your edits), cleared after a successful send. The sent prompt includes each
 comment's file:line plus the repo and branch, so the agent has context.
 
 For a pending-comment indicator (`● 3`) in your statusline:
-`require("herdr-nvim").statusline()` — it returns `""` when nothing is
-pending.
+`require("herdr-nvim").statusline()`.
 
 ## Config
 

--- a/doc/herdr-nvim.txt
+++ b/doc/herdr-nvim.txt
@@ -1,0 +1,263 @@
+INTRODUCTION                                                        *herdr-nvim*
+
+herdr-nvim adds code annotations that you send to herdr agents (pi, claude,
+codex). Comment a line or a selection like a code review, list pending
+comments, then send them all to any agent in your workspace — with file:line
+and git context. The plugin is the nvim half of the herdr workspace plugin;
+the sidebar itself is provided by the herdr side.
+
+Links:
+- Repository: https://github.com/ChmaraX/herdr-nvim
+- herdr: https://herdr.dev
+
+Table of contents:
+
+1. FEATURES: What this plugin provides.                    |herdr-nvim-features|
+2. REQUIREMENTS: Plugin dependencies and setup.        |herdr-nvim-requirements|
+3. INSTALLATION: How to install the plugin.            |herdr-nvim-installation|
+4. CONFIGURATION: Options and suggested keymaps.             |herdr-nvim-config|
+5. COMMANDS: The :Herdr user command.                  |herdr-nvim-commands|
+6. HIGHLIGHTS: Highlight groups.                         |herdr-nvim-highlights|
+7. API: Public Lua functions.                                   |herdr-nvim-api|
+8. EXAMPLES: Statusline and plugin-manager setup.          |herdr-nvim-examples|
+9. DEVELOPMENT: Building and testing.                   |herdr-nvim-development|
+10. TROUBLESHOOTING: Common issues and solutions.   |herdr-nvim-troubleshooting|
+================================================================================
+FEATURES                                                   *herdr-nvim-features*
+
+An annotated block is drawn as three layers:
+
+- a solid amber rail in the sign column, one cell per line of the block
+- a subtle full-width background tint over those same lines
+- a callout above the first line naming the comment
+
+Comments are tracked with extmarks, so they follow your edits. They are
+ephemeral by design: in-memory only, cleared after a successful send.
+
+A pending-comment indicator for your statusline is provided by
+|herdr-nvim.statusline()|.
+================================================================================
+REQUIREMENTS                                           *herdr-nvim-requirements*
+
+- Neovim >= 0.10
+- herdr >= 0.7.4, running inside a herdr session
+- The `herdr` CLI available on PATH (lists agents, sends comments)
+================================================================================
+INSTALLATION                                           *herdr-nvim-installation*
+
+Install the herdr plugin for the sidebar (see the plugin README), and the
+nvim plugin with your plugin manager. With lazy.nvim:
+
+>lua
+  { "ChmaraX/herdr-nvim", opts = {} }
+<
+
+The plugin registers the |herdr-nvim-commands| command when it loads, so
+lazy.nvim can lazy-load it and declare the keymaps in the spec:
+
+>lua
+  {
+    "ChmaraX/herdr-nvim",
+    cmd = { "Herdr" },
+    keys = {
+      { "<leader>a", "", desc = "+AI", mode = { "n", "x" } },
+      { "<leader>ac", "<CMD>Herdr comment<CR>", desc = "Comment" },
+      { "<leader>ac", "<CMD>Herdr comment<CR>", mode = "x" },
+      { "<leader>al", "<CMD>Herdr list<CR>", desc = "List comments" },
+      { "<leader>as", "<CMD>Herdr send<CR>", desc = "Send to agent" },
+      { "<leader>aS", "<CMD>Herdr submit<CR>", desc = "Submit to agent" },
+    },
+    opts = {},
+  }
+<
+
+The leader-only `+AI` entry creates a which-key group; the `mode = "x"`
+`comment` entry shares one key across normal and visual mode.
+
+No plugin manager? It still works in vanilla nvim and in the herdr sidebar
+nvim, whose runtimepath the daemon injects: registration happens both from
+the runtimepath plugin script and from |herdr-nvim.setup()|.
+================================================================================
+CONFIGURATION                                                *herdr-nvim-config*
+
+Default keymaps are on. They use the `prefix` option (default `<leader>a`)
+and never override a map you already set. To bind your own instead, set
+`keymaps = false` and use the Lua API (|herdr-nvim-api|) or the user command
+(|herdr-nvim-commands|).
+
+herdr-nvim.setup({opts}) ~
+  Configure the plugin. Optional — the defaults apply without calling it.
+
+>lua
+  require("herdr-nvim").setup({
+    prefix = "<leader>a",     -- prefix for the default keymaps
+    keymaps = true,           -- set false to bind your own
+    clear_after_send = true,  -- clear comments after a successful send
+  })
+<
+
+Suggested keymaps: ~
+
+Copy-paste these into your config and adjust to taste — either bind the API
+functions directly, or bind through the command:
+
+>lua
+  local hn = require("herdr-nvim")
+  vim.keymap.set("n", "<leader>ac", function() hn.comment_line() end)
+  vim.keymap.set("x", "<leader>ac", function() hn.comment_selection() end)
+  vim.keymap.set("n", "<leader>al", function() hn.list_comments() end)
+  vim.keymap.set("n", "<leader>as", "<Cmd>Herdr send<CR>")
+  vim.keymap.set("n", "<leader>aS", "<Cmd>Herdr submit<CR>")
+<
+
+Prefer declaring keymaps in your plugin-manager spec? A lazy.nvim example
+with a which-key group lives in |herdr-nvim-installation|.
+================================================================================
+COMMANDS                                                   *herdr-nvim-commands*
+
+:Herdr {comment, list, send, submit} ~
+  Scoped command for the annotation actions, with subcommand completion.
+  The command is registered when the plugin loads; registration is
+  idempotent and happens both from the runtimepath plugin script and from
+  |herdr-nvim.setup()|, so it works under lazy.nvim, vanilla nvim, and the
+  herdr daemon's injected-runtimepath install alike.
+
+  - `comment`: Add a comment over the command range. :Herdr comment
+    targets the cursor line; :'<,'>Herdr comment targets the visual
+    selection; an explicit range like :5,10Herdr comment is honored.
+  - `list`: Open the comment list (a float). Hover jumps to the comment,
+    `⏎` edits, `d` deletes, `q`/<Esc> closes.
+  - `send`: Paste all comments into a chosen agent's input (no submit).
+  - `submit`: Paste all comments into a chosen agent's input and submit.
+
+Run :Herdr with no subcommand (or an unknown one) for an error listing
+the valid subcommands.
+================================================================================
+HIGHLIGHTS                                               *herdr-nvim-highlights*
+
+Set with `default = true`, so colourschemes may override them.
+
+                                               *herdr-nvim-HerdrNvimCommentSign*
+HerdrNvimCommentSign ~
+  The amber rail in the sign column and the callout corner. Default: bold
+  amber. Override to retheme.
+
+                                               *herdr-nvim-HerdrNvimCommentText*
+HerdrNvimCommentText ~
+  The callout text. Default: amber. Override to retheme.
+
+                                               *herdr-nvim-HerdrNvimCommentLine*
+HerdrNvimCommentLine ~
+  The background tint under an annotated block. Linked to CursorLine so it
+  tracks the active colourscheme; do not override with a fixed color.
+================================================================================
+API                                                             *herdr-nvim-api*
+
+The public API is the module returned by `require("herdr-nvim")`. All
+other modules in the plugin are private and may change.
+
+                                                            *herdr-nvim.setup()*
+herdr-nvim.setup({opts}) ~
+  Set plugin options. Optional; the defaults apply without it. Options are
+  documented in |herdr-nvim-config|. Ensures the |herdr-nvim-commands|
+  command is registered.
+  Parameters: ~
+    {opts} (`table`) Options. See |herdr-nvim-config|.
+
+                                                    *herdr-nvim.comment_range()*
+herdr-nvim.comment_range({start_line}, {end_line}) ~
+  Add a comment over a 1-indexed, inclusive line range in the current
+  buffer. Prompts for the comment text via vim.ui.input.
+  Parameters: ~
+    {start_line} (`integer`) First line of the range.
+    {end_line} (`integer`) Last line of the range (inclusive).
+
+                                                     *herdr-nvim.comment_line()*
+herdr-nvim.comment_line() ~
+  Add a comment on the current line. Equivalent to
+  |herdr-nvim.comment_range()| with the cursor line.
+
+                                                *herdr-nvim.comment_selection()*
+herdr-nvim.comment_selection() ~
+  Add a comment over the current visual selection.
+
+                                                    *herdr-nvim.list_comments()*
+herdr-nvim.list_comments() ~
+  Open the interactive comment list as a floating window. Cursor movement
+  previews (jumps the code window to) each comment; `⏎` edits, `d` deletes,
+  `q`/<Esc> closes.
+
+                                                     *herdr-nvim.edit_comment()*
+herdr-nvim.edit_comment({comment}, {on_done}) ~
+  Edit a comment's text in place and refresh its decoration. The comment
+  is briefly undecorated while editing, then re-decorated with the new text.
+  Parameters: ~
+    {comment} (`herdr.Comment`) The comment to edit.
+    {on_done} (`function|nil`) Optional callback fired when the input closes.
+
+                                                   *herdr-nvim.delete_comment()*
+herdr-nvim.delete_comment({comment}) ~
+  Remove a comment and its decoration.
+  Parameters: ~
+    {comment} (`herdr.Comment`) The comment to remove.
+
+                                                         *herdr-nvim.send_all()*
+herdr-nvim.send_all({opts}) ~
+  Send all pending comments to a chosen agent (picked via vim.ui.select),
+  preceded by the formatted prompt with file:line and git context.
+  Parameters: ~
+    {opts} (`table`) Options:
+    - `submit` (`boolean`, default false): when true, auto-submits the text
+      into the agent's input instead of just pasting it.
+
+  When |herdr-nvim.setup()| opts `clear_after_send` is true (the default),
+  comments are cleared after a successful send.
+
+                                                       *herdr-nvim.statusline()*
+herdr-nvim.statusline() ~
+  Statusline indicator for pending comments.
+  Return: ~
+    `string` `"● N"` when N comments are pending, or `""` when none.
+================================================================================
+EXAMPLES                                                   *herdr-nvim-examples*
+
+A pending-comment indicator in your statusline: ~
+
+>lua
+  -- inside your statusline component
+  { function() return require("herdr-nvim").statusline() end },
+<
+================================================================================
+DEVELOPMENT                                             *herdr-nvim-development*
+
+The nvim plugin lives under `lua/` and `plugin/`; the herdr daemon and its
+CLI under `src/`.
+
+Run the checks (Rust + headless Lua suite):
+
+>bash
+  just ci
+<
+================================================================================
+TROUBLESHOOTING                                     *herdr-nvim-troubleshooting*
+
+Run the health checks first:
+
+>vim
+  :checkhealth herdr-nvim
+<
+
+Common Issues: ~
+
+Issue: :Herdr is not recognized ~
+- For lazy-loaded installs, the command is registered when the plugin loads
+  (first keypress, or the first :Herdr with `cmd = { "Herdr" }`).
+- If a plugin manager resets 'runtimepath' and the plugin is not installed
+  in your nvim config, :Herdr exists only in the herdr sidebar nvim
+  (whose runtimepath the daemon injects).
+
+Issue: The sidebar daemon does not start ~
+- Make sure `sidebar.nvim_bin` points at a working nvim >= 0.10 (see the
+  plugin README for the herdr-side config).
+
+vim:tw=78:ts=8:et:ft=help:norl:

--- a/lua/herdr-nvim/commands.lua
+++ b/lua/herdr-nvim/commands.lua
@@ -1,0 +1,60 @@
+-- :Herdr user command with scoped subcommands (comment/list/send/submit) and
+-- completions. Private module; the public API lives in herdr-nvim.init.
+local M = {}
+
+local subcommands = { "comment", "list", "send", "submit" }
+
+-- Idempotent: delete-then-create also replaces lazy.nvim's `cmd` placeholder.
+function M.register()
+  pcall(vim.api.nvim_del_user_command, "Herdr")
+  vim.api.nvim_create_user_command("Herdr", function(opts)
+    require("herdr-nvim.commands").run(opts)
+  end, {
+    nargs = "?",
+    range = true,
+    desc = "herdr-nvim: comment, list, send, or submit code annotations",
+    complete = function(arg_lead, cmdline)
+      return require("herdr-nvim.commands").complete(arg_lead, cmdline)
+    end,
+  })
+end
+
+-- Complete the subcommand word only; the cmdline anchor skips any range
+-- prefix (:'<,'>, :5,10) and stops after a full subcommand.
+function M.complete(arg_lead, cmdline)
+  local _, after = cmdline:find("Herdr%s+", 1)
+  if not after then
+    return {}
+  end
+  local lead = cmdline:sub(after + 1)
+  if not lead:match("^%w*$") then
+    return {}
+  end
+  return vim.iter(subcommands)
+    :filter(function(s) return vim.startswith(s, lead) end)
+    :totable()
+end
+
+-- Dispatch a subcommand; `comment` honors the command range (cursor line by
+-- default, or :'<,'>/:5,10 when given).
+function M.run(opts)
+  local hn = require("herdr-nvim")
+  local sub = opts.fargs[1]
+  if sub == "comment" then
+    hn.comment_range(opts.line1, opts.line2)
+  elseif sub == "list" then
+    hn.list_comments()
+  elseif sub == "send" then
+    hn.send_all({ submit = false })
+  elseif sub == "submit" then
+    hn.send_all({ submit = true })
+  else
+    vim.notify(
+      string.format("Herdr: unknown subcommand %q (expected: %s)", sub or "", table.concat(subcommands, ", ")),
+      vim.log.levels.ERROR,
+      { title = "herdr-nvim" }
+    )
+  end
+end
+
+return M

--- a/lua/herdr-nvim/init.lua
+++ b/lua/herdr-nvim/init.lua
@@ -17,6 +17,11 @@ end
 
 function M.setup(config)
   M.config = vim.tbl_deep_extend("force", M.config, config or {})
+  -- Ensure :Herdr is registered (also done from plugin/herdr-nvim.lua).
+  require("herdr-nvim.commands").register()
+  -- Default keymaps stay opt-out (keymaps = true) for backward compatibility.
+  -- Prefer the :Herdr command or the Lua API and set keymaps = false to bind
+  -- your own; see :help herdr-nvim.
   if M.config.keymaps then
     local p = M.config.prefix
     map("x", p .. "c", function() M.comment_selection() end, "herdr-nvim: comment selection")
@@ -27,7 +32,8 @@ function M.setup(config)
   end
 end
 
-local function add_comment(start_line, end_line)
+-- Range primitive behind comment_line(), comment_selection(), and :Herdr comment.
+function M.comment_range(start_line, end_line)
   local bufnr = vim.api.nvim_get_current_buf()
   ui.input_comment(function(text)
     local id = comments.add(bufnr, start_line, end_line, text)
@@ -38,12 +44,12 @@ end
 function M.comment_selection()
   vim.cmd([[execute "normal! \<esc>"]]) -- materialize '< '> marks
   local s, e = ui.visual_range()
-  add_comment(s, e)
+  M.comment_range(s, e)
 end
 
 function M.comment_line()
   local l = vim.api.nvim_win_get_cursor(0)[1]
-  add_comment(l, l)
+  M.comment_range(l, l)
 end
 
 -- Edit a comment's text in place (undecorate → edit → re-decorate so the callout

--- a/plugin/herdr-nvim.lua
+++ b/plugin/herdr-nvim.lua
@@ -1,0 +1,3 @@
+-- Registers the :Herdr user command (deferred require). setup() re-registers
+-- idempotently, covering eager, lazy, and daemon-injected installs alike.
+require("herdr-nvim.commands").register()

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -1,0 +1,116 @@
+local hn = require("herdr-nvim")
+local comments = require("herdr-nvim.comments")
+local commands = require("herdr-nvim.commands")
+
+local function clear_cmd()
+  pcall(vim.api.nvim_del_user_command, "Herdr")
+end
+
+T.test("commands: register creates :Herdr and is idempotent", function()
+  commands.register()
+  T.eq(vim.fn.exists(":Herdr"), 2)
+  commands.register() -- must not error
+  T.eq(vim.fn.exists(":Herdr"), 2)
+  local info = vim.api.nvim_get_commands({}).Herdr
+  T.eq(info.nargs, "?")
+  T.ok(info.range, "command accepts a range")
+end)
+
+T.test("commands: register replaces a pre-existing placeholder", function()
+  clear_cmd()
+  vim.api.nvim_create_user_command("Herdr", function() end, { nargs = "*" })
+  commands.register()
+  T.eq(vim.api.nvim_get_commands({}).Herdr.nargs, "?")
+end)
+
+T.test("commands: complete filters subcommands by lead", function()
+  T.eq(commands.complete("", "Herdr "), { "comment", "list", "send", "submit" })
+  T.eq(commands.complete("s", "Herdr s"), { "send", "submit" })
+  T.eq(commands.complete("c", "Herdr c"), { "comment" })
+  T.eq(commands.complete("co", "Herdr co"), { "comment" })
+  T.eq(commands.complete("x", "Herdr x"), {})
+end)
+
+T.test("commands: complete honors a range and stops after a subcommand", function()
+  T.eq(commands.complete("s", "'<,'>Herdr s"), { "send", "submit" })
+  T.eq(commands.complete("s", "5,10Herdr s"), { "send", "submit" })
+  T.eq(commands.complete("", "Herdr send "), {})
+end)
+
+T.test("commands: run comment forwards the command range", function()
+  local got
+  local orig = hn.comment_range
+  hn.comment_range = function(s, e) got = { s, e } end
+  commands.run({ fargs = { "comment" }, line1 = 2, line2 = 4 })
+  hn.comment_range = orig
+  T.eq(got, { 2, 4 })
+end)
+
+T.test("commands: run send/submit map to the send_all submit flag", function()
+  local got
+  local orig = hn.send_all
+  hn.send_all = function(opts) got = opts end
+  commands.run({ fargs = { "send" } })
+  T.eq(got, { submit = false })
+  commands.run({ fargs = { "submit" } })
+  T.eq(got, { submit = true })
+  hn.send_all = orig
+end)
+
+T.test("commands: run list maps to list_comments", function()
+  local got
+  local orig = hn.list_comments
+  hn.list_comments = function() got = true end
+  commands.run({ fargs = { "list" } })
+  T.eq(got, true)
+  hn.list_comments = orig
+end)
+
+T.test("commands: run notifies on missing or unknown subcommand", function()
+  local orig = vim.notify
+  local msgs = {}
+  vim.notify = function(msg, level) msgs[#msgs + 1] = { msg, level } end
+  commands.run({ fargs = {} })
+  commands.run({ fargs = { "bogus" } })
+  vim.notify = orig
+  T.eq(#msgs, 2)
+  T.eq(msgs[2][2], vim.log.levels.ERROR)
+  T.ok(msgs[2][1]:find("unknown subcommand"))
+end)
+
+T.test("commands: :Herdr comment annotates the cursor line", function()
+  comments.clear()
+  commands.register()
+  local ui = require("herdr-nvim.ui")
+  local orig = ui.input_comment
+  ui.input_comment = function(cb) cb("stub") end
+  local b = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(b, 0, -1, false, { "one", "two", "three" })
+  vim.api.nvim_set_current_buf(b)
+  vim.api.nvim_win_set_cursor(0, { 2, 0 })
+  vim.cmd("Herdr comment") -- no range → cursor line
+  ui.input_comment = orig
+  local list = comments.list()
+  T.eq({ list[1].start_line, list[1].end_line }, { 2, 2 }, "default range is the cursor line")
+end)
+
+T.test("commands: :<range>Herdr comment annotates the range", function()
+  comments.clear()
+  commands.register()
+  local ui = require("herdr-nvim.ui")
+  local orig = ui.input_comment
+  ui.input_comment = function(cb) cb("stub") end
+  local b = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(b, 0, -1, false, { "a", "b", "c", "d" })
+  vim.api.nvim_set_current_buf(b)
+  vim.cmd("1,3Herdr comment")
+  ui.input_comment = orig
+  local list = comments.list()
+  T.eq({ list[1].start_line, list[1].end_line }, { 1, 3 })
+end)
+
+T.test("commands: setup() ensures the command exists", function()
+  clear_cmd()
+  hn.setup({})
+  T.eq(vim.fn.exists(":Herdr"), 2)
+end)

--- a/tests/test_init.lua
+++ b/tests/test_init.lua
@@ -26,6 +26,38 @@ T.test("init: comment_line adds a decorated comment via stubbed input", function
   T.eq({ l[1].start_line, l[1].text }, { 2, "stub comment" })
 end)
 
+T.test("init: comment_selection uses the visual marks", function()
+  comments.clear()
+  local ui = require("herdr-nvim.ui")
+  local orig = ui.input_comment
+  ui.input_comment = function(cb) cb("stub sel") end
+  local b = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(b, 0, -1, false, { "a", "b", "c", "d" })
+  vim.api.nvim_set_current_buf(b)
+  vim.api.nvim_buf_set_mark(b, "<", 2, 0, {})
+  vim.api.nvim_buf_set_mark(b, ">", 4, 0, {})
+  hn.comment_selection()
+  ui.input_comment = orig
+  local list = comments.list()
+  T.eq({ list[1].start_line, list[1].end_line }, { 2, 4 })
+end)
+
+T.test("init: comment_selection normalizes reversed marks", function()
+  comments.clear()
+  local ui = require("herdr-nvim.ui")
+  local orig = ui.input_comment
+  ui.input_comment = function(cb) cb("stub sel") end
+  local b = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(b, 0, -1, false, { "a", "b", "c", "d" })
+  vim.api.nvim_set_current_buf(b)
+  vim.api.nvim_buf_set_mark(b, "<", 4, 0, {})
+  vim.api.nvim_buf_set_mark(b, ">", 2, 0, {})
+  hn.comment_selection()
+  ui.input_comment = orig
+  local list = comments.list()
+  T.eq({ list[1].start_line, list[1].end_line }, { 2, 4 })
+end)
+
 T.test("init: edit_comment updates text and refreshes its callout", function()
   comments.clear()
   local ui = require("herdr-nvim.ui")


### PR DESCRIPTION
Adopts the annotation-API proposal from #8 in a **non-breaking** way: it adds the command and Lua API but **keeps the default keymaps**, so existing users need no config change.

## What it adds
- **`:Herdr {comment,list,send,submit}`** — subcommand tab-completion, range support (cursor line, `:'<,'>`, or `:5,10`), `submit` auto-submits.
- **`comment_range(start, end)`** — shared primitive behind `comment_line()`, `comment_selection()`, and `:Herdr comment`.
- **`doc/herdr-nvim.txt`** vimhelp + README updates.
- **Tests** — `test_commands.lua` (registration/idempotency, completion, range dispatch, unknown subcommand) + visual-selection coverage.

## Non-breaking
- `keymaps = true` stays the default; `prefix` + `keymaps` options unchanged. Default `<leader>a*` maps still ship and still never override an existing map.
- To bind your own: `setup({ keymaps = false })` and map `:Herdr` or the Lua API.

## Difference from #8
The original proposal (`feat!`) dropped the default keymaps. This PR keeps them for backward compatibility; everything else follows the proposal.

## Testing
`nvim --headless --noplugin -u NONE -l tests/run.lua` → **54/54 passed**.

Closes #8

Co-authored-by: S1M0N38 <bertolottosimone@gmail.com>